### PR TITLE
adding flag to force the use of Azure CLI Credentials #186

### DIFF
--- a/cmd/azqr/scan.go
+++ b/cmd/azqr/scan.go
@@ -18,6 +18,7 @@ func init() {
 	scanCmd.PersistentFlags().BoolP("costs", "c", false, "Scan Azure Costs")
 	scanCmd.PersistentFlags().StringP("output-name", "o", "", "Output file name")
 	scanCmd.PersistentFlags().BoolP("mask", "m", true, "Mask the subscription id in the report")
+	scanCmd.PersistentFlags().BoolP("azure-cli-credential", "f", false, "Force the use of Azure CLI Credential")
 	scanCmd.PersistentFlags().BoolP("debug", "", false, "Set log level to debug")
 
 	rootCmd.AddCommand(scanCmd)
@@ -43,17 +44,19 @@ func scan(cmd *cobra.Command, serviceScanners []scanners.IAzureScanner) {
 	cost, _ := cmd.Flags().GetBool("costs")
 	mask, _ := cmd.Flags().GetBool("mask")
 	debug, _ := cmd.Flags().GetBool("debug")
+	forceAzureCliCredential, _ := cmd.Flags().GetBool("azure-credential-type")
 
 	params := internal.ScanParams{
-		SubscriptionID:  subscriptionID,
-		ResourceGroup:   resourceGroupName,
-		OutputName:      outputFileName,
-		Defender:        defender,
-		Advisor:         advisor,
-		Cost:            cost,
-		Mask:            mask,
-		Debug:           debug,
-		ServiceScanners: serviceScanners,
+		SubscriptionID:          subscriptionID,
+		ResourceGroup:           resourceGroupName,
+		OutputName:              outputFileName,
+		Defender:                defender,
+		Advisor:                 advisor,
+		Cost:                    cost,
+		Mask:                    mask,
+		Debug:                   debug,
+		ServiceScanners:         serviceScanners,
+		ForceAzureCliCredential: forceAzureCliCredential,
 	}
 
 	internal.Scan(&params)

--- a/internal/scan.go
+++ b/internal/scan.go
@@ -61,15 +61,16 @@ import (
 )
 
 type ScanParams struct {
-	SubscriptionID  string
-	ResourceGroup   string
-	OutputName      string
-	Defender        bool
-	Advisor         bool
-	Cost           bool
-	Mask            bool
-	Debug           bool
-	ServiceScanners []scanners.IAzureScanner
+	SubscriptionID          string
+	ResourceGroup           string
+	OutputName              string
+	Defender                bool
+	Advisor                 bool
+	Cost                    bool
+	Mask                    bool
+	Debug                   bool
+	ServiceScanners         []scanners.IAzureScanner
+	ForceAzureCliCredential bool
 }
 
 func Scan(params *ScanParams) {
@@ -81,6 +82,7 @@ func Scan(params *ScanParams) {
 	cost := params.Cost
 	mask := params.Mask
 	debug := params.Debug
+	forceAzureCliCredential := params.ForceAzureCliCredential
 
 	// Default level for this example is info, unless debug flag is present
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
@@ -103,9 +105,18 @@ func Scan(params *ScanParams) {
 		outputFile = fmt.Sprintf("%s_%s", "azqr_report", outputFileStamp)
 	}
 
-	cred, err := azidentity.NewDefaultAzureCredential(nil)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to get Azure credentials")
+	var cred azcore.TokenCredential
+	var err error
+	if !forceAzureCliCredential {
+		cred, err = azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to get Azure credentials")
+		}
+	} else {
+		cred, err = azidentity.NewAzureCLICredential(nil)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to get Azure CLI credentials")
+		}
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
# Description

You can now use the `-f` flag to force authentication with Azure CLI credentials.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #186

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
