### PR TITLE
Fixed AppServiceScanner Managed Identity rules

### DIFF
--- a/internal/scanners/asp/rules.go
+++ b/internal/scanners/asp/rules.go
@@ -247,8 +247,11 @@ func (a *AppServiceScanner) getAppRules() map[string]scanners.AzureRule {
 			Recommendation: "App Service should use Managed Identities",
 			Impact:         scanners.ImpactMedium,
 			Eval: func(target interface{}, scanContext *scanners.ScanContext) (bool, string) {
-				c := target.(*armappservice.Site)
-				return c.Identity == nil || c.Identity.Type == nil || *c.Identity.Type == armappservice.ManagedServiceIdentityTypeNone, ""
+				// c := target.(*armappservice.Site)
+				// c.Identity == nil || c.Identity.Type == nil || *c.Identity.Type == armappservice.ManagedServiceIdentityTypeNone
+				// not working because SDK set's Identity to nil even when configured.
+				ok := scanContext.SiteConfig.Properties.ManagedServiceIdentityID != nil || scanContext.SiteConfig.Properties.XManagedServiceIdentityID != nil
+				return !ok, ""
 			},
 			Url: "https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Chttp",
 		},
@@ -377,8 +380,11 @@ func (a *AppServiceScanner) getFunctionRules() map[string]scanners.AzureRule {
 			Recommendation: "Function should use Managed Identities",
 			Impact:         scanners.ImpactMedium,
 			Eval: func(target interface{}, scanContext *scanners.ScanContext) (bool, string) {
-				c := target.(*armappservice.Site)
-				return c.Identity == nil || c.Identity.Type == nil || *c.Identity.Type == armappservice.ManagedServiceIdentityTypeNone, ""
+				// c := target.(*armappservice.Site)
+				// c.Identity == nil || c.Identity.Type == nil || *c.Identity.Type == armappservice.ManagedServiceIdentityTypeNone
+				// not working because SDK set's Identity to nil even when configured.
+				ok := scanContext.SiteConfig.Properties.ManagedServiceIdentityID != nil || scanContext.SiteConfig.Properties.XManagedServiceIdentityID != nil
+				return !ok, ""
 			},
 			Url: "https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Chttp",
 		},
@@ -507,8 +513,11 @@ func (a *AppServiceScanner) getLogicRules() map[string]scanners.AzureRule {
 			Recommendation: "Logic App should use Managed Identities",
 			Impact:         scanners.ImpactMedium,
 			Eval: func(target interface{}, scanContext *scanners.ScanContext) (bool, string) {
-				c := target.(*armappservice.Site)
-				return c.Identity == nil || c.Identity.Type == nil || *c.Identity.Type == armappservice.ManagedServiceIdentityTypeNone, ""
+				// c := target.(*armappservice.Site)
+				// c.Identity == nil || c.Identity.Type == nil || *c.Identity.Type == armappservice.ManagedServiceIdentityTypeNone
+				// not working because SDK set's Identity to nil even when configured.
+				ok := scanContext.SiteConfig.Properties.ManagedServiceIdentityID != nil || scanContext.SiteConfig.Properties.XManagedServiceIdentityID != nil
+				return !ok, ""
 			},
 			Url: "https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Chttp",
 		},

--- a/internal/scanners/asp/rules_test.go
+++ b/internal/scanners/asp/rules_test.go
@@ -401,15 +401,39 @@ func TestAppServiceScanner_AppRules(t *testing.T) {
 			name: "AppServiceScanner Managed Identity None",
 			fields: fields{
 				rule: "app-016",
-				target: &armappservice.Site{
-					Identity: &armappservice.ManagedServiceIdentity{
-						Type: to.Ptr(armappservice.ManagedServiceIdentityTypeNone),
+				target: &armappservice.Site{},
+				scanContext: &scanners.ScanContext{
+					SiteConfig: &armappservice.WebAppsClientGetConfigurationResponse{
+						SiteConfigResource: armappservice.SiteConfigResource{
+							Properties: &armappservice.SiteConfig{
+								ManagedServiceIdentityID: nil,
+							},
+						},
 					},
 				},
-				scanContext: &scanners.ScanContext{},
 			},
 			want: want{
 				broken: true,
+				result: "",
+			},
+		},
+		{
+			name: "AppServiceScanner Managed Identity",
+			fields: fields{
+				rule: "app-016",
+				target: &armappservice.Site{},
+				scanContext: &scanners.ScanContext{
+					SiteConfig: &armappservice.WebAppsClientGetConfigurationResponse{
+						SiteConfigResource: armappservice.SiteConfigResource{
+							Properties: &armappservice.SiteConfig{
+								ManagedServiceIdentityID: to.Ptr(int32(1)),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				broken: false,
 				result: "",
 			},
 		},
@@ -651,15 +675,39 @@ func TestAppServiceScanner_FunctionRules(t *testing.T) {
 			name: "AppServiceScanner Managed Identity None",
 			fields: fields{
 				rule: "func-014",
-				target: &armappservice.Site{
-					Identity: &armappservice.ManagedServiceIdentity{
-						Type: to.Ptr(armappservice.ManagedServiceIdentityTypeNone),
+				target: &armappservice.Site{},
+				scanContext: &scanners.ScanContext{
+					SiteConfig: &armappservice.WebAppsClientGetConfigurationResponse{
+						SiteConfigResource: armappservice.SiteConfigResource{
+							Properties: &armappservice.SiteConfig{
+								ManagedServiceIdentityID: nil,
+							},
+						},
 					},
 				},
-				scanContext: &scanners.ScanContext{},
 			},
 			want: want{
 				broken: true,
+				result: "",
+			},
+		},
+		{
+			name: "AppServiceScanner Managed Identity",
+			fields: fields{
+				rule: "func-014",
+				target: &armappservice.Site{},
+				scanContext: &scanners.ScanContext{
+					SiteConfig: &armappservice.WebAppsClientGetConfigurationResponse{
+						SiteConfigResource: armappservice.SiteConfigResource{
+							Properties: &armappservice.SiteConfig{
+								ManagedServiceIdentityID: to.Ptr(int32(1)),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				broken: false,
 				result: "",
 			},
 		},
@@ -901,15 +949,39 @@ func TestAppServiceScanner_LogicRules(t *testing.T) {
 			name: "AppServiceScanner Managed Identity None",
 			fields: fields{
 				rule: "logics-014",
-				target: &armappservice.Site{
-					Identity: &armappservice.ManagedServiceIdentity{
-						Type: to.Ptr(armappservice.ManagedServiceIdentityTypeNone),
+				target: &armappservice.Site{},
+				scanContext: &scanners.ScanContext{
+					SiteConfig: &armappservice.WebAppsClientGetConfigurationResponse{
+						SiteConfigResource: armappservice.SiteConfigResource{
+							Properties: &armappservice.SiteConfig{
+								ManagedServiceIdentityID: nil,
+							},
+						},
 					},
 				},
-				scanContext: &scanners.ScanContext{},
 			},
 			want: want{
 				broken: true,
+				result: "",
+			},
+		},
+		{
+			name: "AppServiceScanner Managed Identity",
+			fields: fields{
+				rule: "logics-014",
+				target: &armappservice.Site{},
+				scanContext: &scanners.ScanContext{
+					SiteConfig: &armappservice.WebAppsClientGetConfigurationResponse{
+						SiteConfigResource: armappservice.SiteConfigResource{
+							Properties: &armappservice.SiteConfig{
+								ManagedServiceIdentityID: to.Ptr(int32(1)),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				broken: false,
 				result: "",
 			},
 		},


### PR DESCRIPTION
# Description

Fixed AppServiceScanner Managed Identity rules. The presence of managed identities must be checked via SiteConfig instead of the Identity property of the Sites object.
 
## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: ##211

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
