### PR TITLE
Fix panic from wrong type conversion in ng rules

### DIFF
--- a/internal/scanners/ng/rules.go
+++ b/internal/scanners/ng/rules.go
@@ -20,7 +20,7 @@ func (a *NatGatewayScanner) GetRecommendations() map[string]azqr.AzqrRecommendat
 			Recommendation:   "NAT Gateway should have diagnostic settings enabled",
 			Impact:           azqr.ImpactLow,
 			Eval: func(target interface{}, scanContext *azqr.ScanContext) (bool, string) {
-				service := target.(*armnetwork.SecurityGroup)
+				service := target.(*armnetwork.NatGateway)
 				_, ok := scanContext.DiagnosticsSettings[strings.ToLower(*service.ID)]
 				return !ok, ""
 			},
@@ -45,7 +45,7 @@ func (a *NatGatewayScanner) GetRecommendations() map[string]azqr.AzqrRecommendat
 			Recommendation:   "NAT Gateway Name should comply with naming conventions",
 			Impact:           azqr.ImpactLow,
 			Eval: func(target interface{}, scanContext *azqr.ScanContext) (bool, string) {
-				c := target.(*armnetwork.SecurityGroup)
+				c := target.(*armnetwork.NatGateway)
 				caf := strings.HasPrefix(*c.Name, "ng")
 				return !caf, ""
 			},
@@ -58,7 +58,7 @@ func (a *NatGatewayScanner) GetRecommendations() map[string]azqr.AzqrRecommendat
 			Recommendation:   "NAT Gateway should have tags",
 			Impact:           azqr.ImpactLow,
 			Eval: func(target interface{}, scanContext *azqr.ScanContext) (bool, string) {
-				c := target.(*armnetwork.SecurityGroup)
+				c := target.(*armnetwork.NatGateway)
 				return len(c.Tags) == 0, ""
 			},
 			LearnMoreUrl: "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources?tabs=json",


### PR DESCRIPTION
# Description

This fixes a panic caused by a wrong type conversion in the NAT Gateway scanner rules (copy-paste issue) since 2.0.0:

```
panic: interface conversion: interface {} is *armnetwork.NatGateway, not *armnetwork.SecurityGroup

goroutine 172 [running]:
github.com/Azure/azqr/internal/scanners/ng.(*NatGatewayScanner).GetRecommendations.func4({0xc4df5a0?, 0xc00040a960?}, 0xc000180f90?)
```

## Issue reference

n/a

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
