### PR TITLE
Normalize --subscription-id to Lowercase for Case-Insensitive Handling

### DIFF
--- a/cmd/azqr/scan.go
+++ b/cmd/azqr/scan.go
@@ -56,6 +56,10 @@ func scan(cmd *cobra.Command, scannerKeys []string) {
 	filtersFile, _ := cmd.Flags().GetString("filters")
 	useAzqr, _ := cmd.Flags().GetBool("azqr")
 
+	// Normalize lowercase for case-insensitive handling
+	subscriptionID = strings.ToLower(subscriptionID)
+
+	
 	// load filters
 	filters := scanners.LoadFilters(filtersFile, scannerKeys)
 


### PR DESCRIPTION
This pull request introduces a change to normalize the --subscription-id parameter to lowercase in the scan command. This ensures that the parameter is handled in a case-insensitive manner, improving usability and preventing potential issues caused by case mismatches.
