### PR TITLE
feat: scan prints impacted services json to stdout #496

### DIFF
--- a/cmd/azqr/commands/scan.go
+++ b/cmd/azqr/commands/scan.go
@@ -20,12 +20,12 @@ func init() {
 	scanCmd.PersistentFlags().BoolP("xslx", "", true, "Create Excel report (default)")
 	scanCmd.PersistentFlags().BoolP("json", "", false, "Create JSON report files")
 	scanCmd.PersistentFlags().BoolP("csv", "", false, "Create CSV report files")
+	scanCmd.PersistentFlags().BoolP("stdout", "", false, "Create CSV report files")
 	scanCmd.PersistentFlags().StringP("output-name", "o", "", "Output file name without extension")
 	scanCmd.PersistentFlags().BoolP("mask", "m", true, "Mask the subscription id in the report (default)")
-
-	scanCmd.PersistentFlags().BoolP("debug", "", false, "Set log level to debug")
 	scanCmd.PersistentFlags().StringP("filters", "e", "", "Filters file (YAML format)")
 	scanCmd.PersistentFlags().BoolP("azqr", "", true, "Scan Azure Quick Review Recommendations (default)")
+	scanCmd.PersistentFlags().BoolP("debug", "", false, "Set log level to debug")
 
 	rootCmd.AddCommand(scanCmd)
 }
@@ -54,7 +54,7 @@ func scan(cmd *cobra.Command, scannerKeys []string) {
 	json, _ := cmd.Flags().GetBool("json")
 	mask, _ := cmd.Flags().GetBool("mask")
 	debug, _ := cmd.Flags().GetBool("debug")
-
+	stdout, _ := cmd.Flags().GetBool("stdout")
 	filtersFile, _ := cmd.Flags().GetString("filters")
 	useAzqr, _ := cmd.Flags().GetBool("azqr")
 
@@ -62,21 +62,22 @@ func scan(cmd *cobra.Command, scannerKeys []string) {
 	filters := models.LoadFilters(filtersFile, scannerKeys)
 
 	params := internal.ScanParams{
-		ManagementGroups:        managementGroups,
-		Subscriptions:           subscriptions,
-		ResourceGroups:          resourceGroups,
-		OutputName:              outputFileName,
-		Defender:                defender,
-		Advisor:                 advisor,
-		Xlsx:                    xlsx,
-		Cost:                    cost,
-		Csv:                     csv,
-		Json:                    json,
-		Mask:                    mask,
-		Debug:                   debug,
-		ScannerKeys:             scannerKeys,
-		Filters:                 filters,
-		UseAzqrRecommendations:  useAzqr,
+		ManagementGroups:       managementGroups,
+		Subscriptions:          subscriptions,
+		ResourceGroups:         resourceGroups,
+		OutputName:             outputFileName,
+		Defender:               defender,
+		Advisor:                advisor,
+		Xlsx:                   xlsx,
+		Cost:                   cost,
+		Csv:                    csv,
+		Json:                   json,
+		Mask:                   mask,
+		Stdout:                 stdout,
+		Debug:                  debug,
+		ScannerKeys:            scannerKeys,
+		Filters:                filters,
+		UseAzqrRecommendations: useAzqr,
 	}
 
 	scanner := internal.Scanner{}

--- a/internal/renderers/json/json.go
+++ b/internal/renderers/json/json.go
@@ -33,6 +33,18 @@ func CreateJsonReport(data *renderers.ReportData) {
 	writeData(consolidatedReport, filename)
 }
 
+func CreateJsonOutput(data *renderers.ReportData) string {
+	// Build consolidated JSON structure
+	impacted := convertToJSON(data.ImpactedTable())
+
+	js, err := json.MarshalIndent(impacted, "", "\t")
+	if err != nil {
+		log.Fatal().Err(err).Msg("error marshaling data:")
+	}
+
+	return string(js)
+}
+
 // writeData writes the consolidated JSON data to a single file
 func writeData(data map[string]interface{}, filename string) {
 	f, err := os.Create(filename)

--- a/internal/scanner.go
+++ b/internal/scanner.go
@@ -98,22 +98,23 @@ import (
 
 type (
 	ScanParams struct {
-		ManagementGroups        []string
-		Subscriptions           []string
-		ResourceGroups          []string
-		OutputName              string
-		Defender                bool
-		Advisor                 bool
-		Xlsx                    bool
-		Cost                    bool
-		Mask                    bool
-		Csv                     bool
-		Json                    bool
-		Debug                   bool
-		ScannerKeys             []string
-		Filters                 *models.Filters
-		UseAzqrRecommendations  bool
-		UseAprlRecommendations  bool
+		ManagementGroups       []string
+		Subscriptions          []string
+		ResourceGroups         []string
+		OutputName             string
+		Defender               bool
+		Advisor                bool
+		Xlsx                   bool
+		Cost                   bool
+		Mask                   bool
+		Csv                    bool
+		Json                   bool
+		Stdout                 bool
+		Debug                  bool
+		ScannerKeys            []string
+		Filters                *models.Filters
+		UseAzqrRecommendations bool
+		UseAprlRecommendations bool
 	}
 
 	Scanner struct{}
@@ -126,25 +127,25 @@ const (
 
 func NewScanParams() *ScanParams {
 	return &ScanParams{
-		ManagementGroups:        []string{},
-		Subscriptions:           []string{},
-		ResourceGroups:          []string{},
-		OutputName:              "",
-		Defender:                true,
-		Advisor:                 true,
-		Cost:                    true,
-		Mask:                    true,
-		Csv:                     false,
-		Json:                    false,
-		Debug:                   false,
-		ScannerKeys:             []string{},
-		Filters:                 models.NewFilters(),
-		UseAzqrRecommendations:  true,
-		UseAprlRecommendations:  true,
+		ManagementGroups:       []string{},
+		Subscriptions:          []string{},
+		ResourceGroups:         []string{},
+		OutputName:             "",
+		Defender:               true,
+		Advisor:                true,
+		Cost:                   true,
+		Mask:                   true,
+		Csv:                    false,
+		Json:                   false,
+		Debug:                  false,
+		ScannerKeys:            []string{},
+		Filters:                models.NewFilters(),
+		UseAzqrRecommendations: true,
+		UseAprlRecommendations: true,
 	}
 }
 
-func (sc Scanner) Scan(params *ScanParams) {
+func (sc Scanner) Scan(params *ScanParams) string {
 	startTime := time.Now()
 	// Default level for this example is info, unless debug flag is present
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
@@ -391,12 +392,20 @@ func (sc Scanner) Scan(params *ScanParams) {
 		csv.CreateCsvReport(&reportData)
 	}
 
+	// Write the JSON output to stdout
+	outputJson := json.CreateJsonOutput(&reportData)
+	if params.Stdout {
+		fmt.Println(outputJson)
+	}
+
 	elapsedTime := time.Since(startTime)
 	// Format the elapsed time as HH:MM:SS and log the scan completion time
 	hours := int(elapsedTime.Hours())
 	minutes := int(elapsedTime.Minutes()) % 60
 	seconds := int(elapsedTime.Seconds()) % 60
 	log.Info().Msgf("Scan completed in %02d:%02d:%02d", hours, minutes, seconds)
+
+	return outputJson
 }
 
 // retry retries the Azure scanner Scan, a number of times with an increasing delay between retries


### PR DESCRIPTION
# Description

Scan now prints impacted services json to stdout if the `--stdout` flag is set

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #496 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
