### PR TITLE
Update _index.md

### DIFF
--- a/docs/content/en/docs/Usage/_index.md
+++ b/docs/content/en/docs/Usage/_index.md
@@ -24,7 +24,7 @@ weight: 3
 Set `AZURE_TOKEN_CREDENTIALS=dev` to use Azure CLI (`az`) or Azure Developer CLI (`azd`) credentials.
 
 **Production environments:** 
-Set `AZURE_TOKEN_CREDENTIALS=pro` to use environment variables, workload identity, or managed identity credentials.
+Set `AZURE_TOKEN_CREDENTIALS=prod` to use environment variables, workload identity, or managed identity credentials.
 
 ### Service Principal Authentication
 


### PR DESCRIPTION
while reading the docs, and updating some scripts I have I found this spelling mistake of `pro` to be `prod`

```
CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException
FullyQualifiedErrorId : RuntimeException
Message     : 2025-09-05T18:17:38Z FTL Failed to get Azure credentials error="invalid AZURE_TOKEN_CREDENTIALS value \"pro\". Valid values are \"dev\", \"prod\", or the name of any credential type in the default chain. See https://aka.ms/azsdk/go/identity/docs#DefaultAzureCredential for more information"
```