### PR TITLE
Fix GitInfo Page Edit

### DIFF
--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -115,7 +115,7 @@ github_repo = "https://github.com/azure/azqr"
 github_project_repo = "https://github.com/azure/azqr"
 
 # Specify a value here if your content directory is not in your repo's root directory
-# github_subdir = "docs"
+github_subdir = "docs"
 
 # Uncomment this if your GitHub repo does not have "main" as the default branch,
 # or specify a new value if you want to reference another branch in your GitHub links


### PR DESCRIPTION
# Description
Currently the Edit Page hyperlink is not correct so when trying to edit a page from the website

<img width="1590" height="381" alt="image" src="https://github.com/user-attachments/assets/02dc243a-bca5-4efb-bc60-1ea7b9f4ba87" />


you get given this error in github

<img width="725" height="243" alt="image" src="https://github.com/user-attachments/assets/3c65d540-292e-4d67-9c28-cbca3e7bf0e2" />

This is be cause currently the docys theme assumes the content folder is in the root of the github main branch, However this is not the case and its lives under `docs`

to confirm this, if we open the url with the additionla `docs` path in 

```
https://github.com/azure/azqr/edit/main/**docs**/content/en/docs/_index.md
```

the page loads.

Having read through the docys site, My understanding is we need to enable the github_subdir value in this PR to add the missing path in :) 

``` toml
# Specify a value here if your content directory is not in your repo's root directory
# github_subdir = "docs"
github_subdir = "docs"
```
