### PR TITLE
fix(viewer): normalize input paths and use path.Join for embedded files #620

### DIFF
--- a/internal/viewer/datastore.go
+++ b/internal/viewer/datastore.go
@@ -59,7 +59,9 @@ func LoadDataStore(path string) (*DataStore, error) {
 
 // loadJSONDataStore loads a JSON format report (original implementation).
 func loadJSONDataStore(path string) (*DataStore, error) {
-	f, err := os.Open(path)
+	// Clean and normalize the path for cross-platform compatibility
+	cleanPath := filepath.Clean(path)
+	f, err := os.Open(cleanPath)
 	if err != nil {
 		return nil, fmt.Errorf("open json file: %w", err)
 	}

--- a/internal/viewer/excel_parser.go
+++ b/internal/viewer/excel_parser.go
@@ -5,6 +5,7 @@ package viewer
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/xuri/excelize/v2"
@@ -12,7 +13,9 @@ import (
 
 // ExcelToDataStore parses an Excel file and converts it to the same DataStore format as JSON files.
 func ExcelToDataStore(path string) (*DataStore, error) {
-	f, err := excelize.OpenFile(path)
+	// Clean and normalize the path for cross-platform compatibility
+	cleanPath := filepath.Clean(path)
+	f, err := excelize.OpenFile(cleanPath)
 	if err != nil {
 		return nil, fmt.Errorf("open excel file: %w", err)
 	}

--- a/internal/viewer/server.go
+++ b/internal/viewer/server.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -46,7 +45,8 @@ func NewHandler(ds *DataStore) http.Handler {
 			return
 		}
 		clean := strings.TrimPrefix(path.Clean(p), "/")
-		fp := filepath.Join("static", clean)
+		// Use path.Join instead of filepath.Join for embed.FS (always uses forward slashes)
+		fp := path.Join("static", clean)
 		if _, err := staticFS.Open(fp); err == nil {
 			serveStatic(w, fp)
 			return


### PR DESCRIPTION
# Description

fix(viewer): normalize input paths and use path.Join for embedded files 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #620 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
