### PR TITLE
Fix: carbon-emissions adjust toTime calculation for first week of month

### DIFF
--- a/internal/scanners/plugins/carbon/emissions.go
+++ b/internal/scanners/plugins/carbon/emissions.go
@@ -62,7 +62,13 @@ func (s *EmissionsScanner) Scan(ctx context.Context, cred azcore.TokenCredential
 
 	now := time.Now().UTC()
 	firstOfCurrentMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	toTime := firstOfCurrentMonth.AddDate(0, -1, 0)
+	// Determine the "toTime" based on whether we are in the first week of the current month
+	var toTime time.Time
+	if now.Day() <= 7 {
+		toTime = firstOfCurrentMonth.AddDate(0, -2, 0)
+	} else {
+		toTime = firstOfCurrentMonth.AddDate(0, -1, 0)
+	}
 	fromTime := toTime
 
 	// Initialize client options


### PR DESCRIPTION
When running during the first 7 days of a month use the month-before-last as the report end date to avoid incomplete current-month data; otherwise use the previous month.

# Description

Fix: carbon-emissions adjust toTime calculation for first week of month

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #629 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
