### PR TITLE
feat: add daily granularity to cost queries

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -174,7 +174,7 @@ type (
 
 	// CostResultItem - Cost result,
 	CostResultItem struct {
-		SubscriptionID, SubscriptionName, ServiceName, Value, Currency string
+		SubscriptionID, SubscriptionName, ServiceName, Value, Currency, Date string
 	}
 
 	// AdvisorResult - Advisor result

--- a/internal/renderers/report_data.go
+++ b/internal/renderers/report_data.go
@@ -128,13 +128,14 @@ func (rd *ReportData) ImpactedTable() [][]string {
 }
 
 func (rd *ReportData) CostTable() [][]string {
-	headers := []string{"From", "To", "Subscription Id", "Subscription Name", "Service Name", "Value", "Currency"}
+	headers := []string{"From", "To", "Date", "Subscription Id", "Subscription Name", "Service Name", "Value", "Currency"}
 
 	rows := [][]string{}
 	for _, r := range rd.Cost.Items {
 		row := []string{
 			rd.Cost.From.Format("2006-01-02"),
 			rd.Cost.To.Format("2006-01-02"),
+			r.Date,
 			MaskSubscriptionID(r.SubscriptionID, rd.Mask),
 			r.SubscriptionName,
 			r.ServiceName,

--- a/internal/viewer/server_test.go
+++ b/internal/viewer/server_test.go
@@ -15,7 +15,7 @@ var sample = &DataStore{Data: map[string][]map[string]string{
 	DataSetAzurePolicy:             {{"complianceState": "NonCompliant"}},
 	DataSetDefender:                {},
 	DataSetDefenderRecommendations: {},
-	DataSetCosts:                   {{"value": "10.50"}},
+	DataSetCosts:                   {{"value": "10.50", "date": "2024-01-15"}},
 	DataSetOutOfScope:              {},
 }}
 


### PR DESCRIPTION
This pull request enables daily granularity for Azure Cost Management API queries, providing per-day cost breakdowns instead of aggregated totals. This allows users to identify cost spikes on specific days and perform better trend analysis.

## Cost query enhancements

- Enabled `GranularityTypeDaily` in the cost query dataset configuration, changing from aggregated to daily cost reporting. [1]
- Added `Date` field to `CostResultItem` model to store the usage date for each cost entry. [1]
- Updated response parsing to handle the new column order when daily granularity is used (`[Cost, UsageDate, ServiceName, Currency]`). [1]
- Added date parsing logic to convert the API's YYYYMMDD numeric format to a readable YYYY-MM-DD string format. [1]

## Report output updates

- Added "Date" column to the cost table headers and included the date value in each row of the cost report output. [1]

## Test updates

- Updated sample test data to include the new `date` field. [1]

## Open question

Should this be behind an optional flag (e.g., `--cost-daily`) for users who prefer aggregated data, or is daily granularity preferred as the new default? Happy to add a flag if that's preferred.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing