### PR TITLE
feat: add zone mapping plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,83 @@ You can compare two azqr scan reports to identify differences in recommendations
 ./azqr compare --file1 scan1.xlsx --file2 scan2.xlsx --output comparison.txt
 ```
 
+## Advanced Features
+
+Azure Quick Review includes optional **internal plugins** that provide advanced analytics beyond standard compliance recommendations. These plugins are disabled by default and must be explicitly enabled.
+
+### OpenAI Throttling Monitor
+
+**Flag**: `--openai-throttling`
+
+Monitors Azure OpenAI and Cognitive Services accounts for throttling (HTTP 429 errors) to identify capacity constraints.
+
+- Tracks throttling by hour, model, and deployment
+- Analyzes spillover configuration effectiveness  
+- Reports request counts by status code
+
+**Use Cases**: Capacity planning, troubleshooting throttling, optimizing deployment configuration
+
+```bash
+# Monitor OpenAI throttling across subscriptions
+./azqr scan --openai-throttling
+```
+
+### Carbon Emissions Tracking
+
+**Flag**: `--carbon-emissions`
+
+Analyzes carbon emissions by Azure resource type to support sustainability reporting and optimization.
+
+- Tracks emissions by resource type
+- Calculates month-over-month trends
+- Aggregates across subscriptions
+
+**Use Cases**: Sustainability reporting, compliance, environmental impact analysis
+
+```bash
+# Generate carbon emissions report
+./azqr scan --carbon-emissions
+```
+
+### Zone Mapping
+
+**Flag**: `--zone-mapping`
+
+Retrieves logical-to-physical availability zone mappings for all Azure regions in each subscription.
+
+- Maps logical zones (1, 2, 3) to physical zone identifiers
+- Reveals subscription-specific zone mappings
+- Essential for multi-subscription architectures
+
+**Use Cases**: Multi-subscription architecture design, DR planning with zone awareness, zone alignment
+
+```bash
+# Get zone mappings for all subscriptions
+./azqr scan --zone-mapping
+
+# Compare mappings across subscriptions
+./azqr scan --subscription-id sub1 --subscription-id sub2 --zone-mapping
+```
+
+[📖 Full Documentation](https://azure.github.io/azqr/docs/plugins/zone-mapping/)
+
+### Combining Features
+
+```bash
+# Run multiple plugins together
+./azqr scan --subscription-id <sub-id> \
+  --openai-throttling \
+  --carbon-emissions \
+  --zone-mapping \
+  --output-name comprehensive-analysis
+```
+
+Results from all enabled plugins are included in the Excel, JSON, or CSV output.
+
+> 💡 **Tip**: Plugin results appear in dedicated sheets (Excel) or sections (JSON/CSV). Use `azqr plugins list` to see all available plugins.
+
+[📖 Internal Plugins Documentation](https://azure.github.io/azqr/docs/plugins/internal-plugins/)
+
 ## Binary Verification
 
 To verify the authenticity of downloaded binaries, see our [Binary Verification Guide](SECURITY_VERIFICATION.md).

--- a/cmd/azqr/main.go
+++ b/cmd/azqr/main.go
@@ -9,6 +9,7 @@ import (
 	// Import internal plugins to register them
 	_ "github.com/Azure/azqr/internal/scanners/plugins/carbon"
 	_ "github.com/Azure/azqr/internal/scanners/plugins/openai"
+	_ "github.com/Azure/azqr/internal/scanners/plugins/zone"
 )
 
 func main() {

--- a/docs/content/en/docs/Plugins/internal-plugins.md
+++ b/docs/content/en/docs/Plugins/internal-plugins.md
@@ -1,0 +1,253 @@
+---
+title: Internal Plugins
+description: Built-in analysis plugins for advanced Azure resource insights
+weight: 2
+---
+
+## Overview
+
+Azure Quick Review (azqr) includes **internal plugins** - specialized built-in scanners that provide advanced analytics beyond standard best practice recommendations. Unlike YAML plugins (which add custom Resource Graph queries), internal plugins perform complex data analysis, API integrations, and multi-source data correlation.
+
+Internal plugins are disabled by default and must be explicitly enabled using command-line flags.
+
+## Available Internal Plugins
+
+### 1. OpenAI Throttling
+
+**Plugin Name**: `openai-throttling`  
+**Flag**: `--openai-throttling`  
+**Version**: 1.0.0
+
+Monitors Azure OpenAI and Cognitive Services accounts for throttling (429 errors) to identify capacity constraints.
+
+**Key Features**:
+- Tracks 429 throttling errors by hour, model, and deployment
+- Analyzes spillover configuration effectiveness
+- Reports request counts by status code
+- Identifies peak throttling periods
+
+**Use Cases**:
+- Capacity planning for OpenAI deployments
+- Troubleshooting throttling issues
+- Optimizing deployment spillover configuration
+- Monitoring API usage patterns
+
+**Output Columns**:
+- Subscription, Resource Group, Account Name
+- Kind (OpenAI, Cognitive Services)
+- SKU and deployment details
+- Model name and spillover settings
+- Hourly throttling statistics (status code, request count)
+
+**Data Source**: Azure Monitor Metrics API (last 24-48 hours)
+
+---
+
+### 2. Carbon Emissions
+
+**Plugin Name**: `carbon-emissions`  
+**Flag**: `--carbon-emissions`  
+**Version**: 1.0.0
+
+Analyzes carbon emissions by Azure resource type to support sustainability reporting and optimization.
+
+**Key Features**:
+- Tracks emissions by resource type across subscriptions
+- Calculates month-over-month change ratios
+- Aggregates emissions from multiple subscriptions
+- Supports sustainability compliance reporting
+
+**Use Cases**:
+- Sustainability reporting and compliance
+- Identifying high-emission resource types
+- Tracking carbon reduction progress
+- Environmental impact analysis
+
+**Output Columns**:
+- Period From/To (reporting period)
+- Resource Type
+- Latest Month Emissions
+- Previous Month Emissions
+- Month-over-Month Change Ratio
+- Monthly Change Value
+- Unit (metric tons CO2 equivalent)
+
+**Data Source**: Azure Carbon Optimization API
+
+---
+
+### 3. Zone Mapping
+
+**Plugin Name**: `zone-mapping`  
+**Flag**: `--zone-mapping`  
+**Version**: 1.0.0
+
+Retrieves logical-to-physical availability zone mappings for all Azure regions in each subscription.
+
+**Key Features**:
+- Maps logical zones (1, 2, 3) to physical zone identifiers
+- Reveals subscription-specific zone mappings
+- Helps ensure proper zone alignment across subscriptions
+- Supports multi-subscription architecture planning
+
+**Use Cases**:
+- Multi-subscription architecture design
+- DR planning with zone awareness
+- Zone alignment for latency optimization
+- Compliance and audit documentation
+
+**Output Columns**:
+- Subscription, Location, Display Name
+- Logical Zone (1, 2, or 3)
+- Physical Zone (e.g., `eastus-az1`, `westeurope-az2`)
+
+**Data Source**: Azure Resource Manager Subscriptions API
+
+[📖 Full Documentation](./zone-mapping)
+
+---
+
+## Usage
+
+### Enabling Internal Plugins
+
+Internal plugins are opt-in and must be enabled individually using command-line flags:
+
+```bash
+# Enable OpenAI throttling plugin
+azqr scan --openai-throttling
+
+# Enable carbon emissions plugin
+azqr scan --carbon-emissions
+
+# Enable zone mapping plugin
+azqr scan --zone-mapping
+
+# Enable multiple plugins
+azqr scan --openai-throttling --carbon-emissions --zone-mapping
+
+# Combine with other scan options
+azqr scan --subscription-id <sub-id> --output-name analysis
+```
+
+### Listing Available Plugins
+
+View all registered plugins (internal and YAML):
+
+```bash
+azqr plugins list
+```
+
+**Sample Output**:
+```
+NAME                  VERSION    TYPE       DESCRIPTION
+openai-throttling     1.0.0      internal   Checks OpenAI/Cognitive Services accounts for...
+carbon-emissions      1.0.0      internal   Analyzes carbon emissions by Azure resource type
+zone-mapping          1.0.0      internal   Retrieves logical-to-physical availability zone mappings...
+```
+
+### Plugin Details
+
+Get detailed information about a specific plugin:
+
+```bash
+azqr plugins info zone-mapping
+```
+
+## Output Formats
+
+Internal plugin results are included in all output formats:
+
+### Excel (Default)
+
+Each internal plugin creates a dedicated worksheet in the Excel workbook:
+- **Zone Mapping** sheet
+- **OpenAI Throttling** sheet  
+- **Carbon Emissions** sheet
+
+```bash
+azqr scan --openai-throttling --carbon-emissions --zone-mapping
+# Generates: azqr_action_plan_YYYY_MM_DD_THHMMSS.xlsx
+```
+
+### JSON
+
+Plugin results are included in the `pluginResults` array:
+
+```bash
+azqr scan --zone-mapping --json
+```
+
+**JSON Structure**:
+```json
+{
+  "recommendations": [...],
+  "resources": [...],
+  "pluginResults": [
+    {
+      "pluginName": "zone-mapping",
+      "sheetName": "Zone Mapping",
+      "description": "Retrieves logical-to-physical availability zone mappings for all Azure regions in each subscription",
+      "table": [
+        ["Subscription", "Location", "Display Name", "Logical Zone", "Physical Zone"],
+        ["Production", "East US", "East US", "1", "eastus-az1"]
+      ]
+    }
+  ]
+}
+```
+
+### CSV
+
+Plugin results are exported to separate CSV files:
+
+```bash
+azqr scan --zone-mapping --csv
+# Generates: 
+#   <filename>.zone-mapping.csv
+#   <filename>.recommendations.csv
+#   <filename>.inventory.csv
+#   ...
+```
+
+## Interactive Dashboard
+
+View plugin results interactively using the `show` command:
+
+```bash
+# Generate report with plugins
+azqr scan --openai-throttling --carbon-emissions --zone-mapping --output-name analysis
+
+# Launch interactive viewer
+azqr show -f analysis.xlsx --open
+```
+
+The dashboard provides:
+- Filterable columns (dropdowns, search)
+- Sortable data tables
+- Export capabilities
+- Real-time filtering
+
+## Permissions
+
+Internal plugins may require additional permissions beyond standard `Reader` access:
+
+| Plugin | Required Permissions | API Dependencies |
+|--------|---------------------|------------------|
+| **zone-mapping** | Reader | Subscriptions API (locations endpoint) |
+| **openai-throttling** | Reader + Monitoring Reader | Cognitive Services, Monitor Metrics |
+| **carbon-emissions** | Reader | Carbon Optimization API |
+
+**Recommended**: Assign `Reader` and `Monitoring Reader` roles at subscription or management group scope.
+
+## Performance Considerations
+
+Internal plugins add processing time to scans:
+
+- **openai-throttling**: 1-3 minutes (depends on number of OpenAI accounts)
+- **carbon-emissions**: 1-2 minutes (depends on subscription count)
+- **zone-mapping**: <10 seconds (very fast, one API call per subscription)
+
+**Optimization Tips**:
+- Enable only needed plugins
+- Use subscription/resource group filters to reduce scope

--- a/internal/scanners/plugins/zone/mapping.go
+++ b/internal/scanners/plugins/zone/mapping.go
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package zone
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"sync"
+
+	"github.com/Azure/azqr/internal/models"
+	"github.com/Azure/azqr/internal/plugins"
+	"github.com/Azure/azqr/internal/throttling"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/rs/zerolog/log"
+)
+
+// ZoneMappingScanner is an internal plugin that retrieves availability zone mappings
+type ZoneMappingScanner struct{}
+
+// NewZoneMappingScanner creates a new zone mapping scanner
+func NewZoneMappingScanner() *ZoneMappingScanner {
+	return &ZoneMappingScanner{}
+}
+
+// GetMetadata returns plugin metadata
+func (s *ZoneMappingScanner) GetMetadata() plugins.PluginMetadata {
+	return plugins.PluginMetadata{
+		Name:        "zone-mapping",
+		Version:     "1.0.0",
+		Description: "Retrieves logical-to-physical availability zone mappings for all Azure regions in each subscription",
+		Author:      "Azure Quick Review Team",
+		License:     "MIT",
+		Type:        plugins.PluginTypeInternal,
+		ColumnMetadata: []plugins.ColumnMetadata{
+			{Name: "Subscription", DataKey: "subscription", FilterType: plugins.FilterTypeSearch},
+			{Name: "Location", DataKey: "location", FilterType: plugins.FilterTypeDropdown},
+			{Name: "Display Name", DataKey: "displayName", FilterType: plugins.FilterTypeDropdown},
+			{Name: "Logical Zone", DataKey: "logicalZone", FilterType: plugins.FilterTypeDropdown},
+			{Name: "Physical Zone", DataKey: "physicalZone", FilterType: plugins.FilterTypeSearch},
+		},
+	}
+}
+
+// Scan executes the plugin and returns table data
+func (s *ZoneMappingScanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscriptions map[string]string, filters *models.Filters) (*plugins.ExternalPluginOutput, error) {
+	log.Info().Msg("Scanning availability zone mappings across subscriptions")
+
+	// Initialize table with headers
+	table := [][]string{
+		{"Subscription", "Location", "Display Name", "Logical Zone", "Physical Zone"},
+	}
+
+	// Use parallel processing for performance
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	results := make([]zoneMappingResult, 0)
+
+	// Process subscriptions in parallel with worker pool
+	const maxWorkers = 5
+	semaphore := make(chan struct{}, maxWorkers)
+
+	for subID, subName := range subscriptions {
+		wg.Add(1)
+		go func(subscriptionID, subscriptionName string) {
+			defer wg.Done()
+
+			// Acquire semaphore
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			log.Debug().Msgf("Fetching zone mappings for subscription: %s", subscriptionName)
+
+			subResults, err := s.fetchZoneMappings(ctx, cred, subscriptionID, subscriptionName)
+			if err != nil {
+				log.Error().
+					Err(err).
+					Str("subscription", subscriptionName).
+					Msg("Failed to fetch zone mappings")
+				return
+			}
+
+			// Thread-safe append
+			mu.Lock()
+			results = append(results, subResults...)
+			mu.Unlock()
+
+			log.Debug().Msgf("Fetched %d zone mappings for subscription: %s", len(subResults), subscriptionName)
+		}(subID, subName)
+	}
+
+	wg.Wait()
+
+	log.Info().Msgf("Total zone mappings retrieved: %d", len(results))
+
+	// Sort results for consistent output
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].subscriptionName != results[j].subscriptionName {
+			return results[i].subscriptionName < results[j].subscriptionName
+		}
+		if results[i].location != results[j].location {
+			return results[i].location < results[j].location
+		}
+		return results[i].logicalZone < results[j].logicalZone
+	})
+
+	// Convert results to table format
+	for _, result := range results {
+		table = append(table, []string{
+			result.subscriptionName,
+			result.location,
+			result.displayName,
+			result.logicalZone,
+			result.physicalZone,
+		})
+	}
+
+	return &plugins.ExternalPluginOutput{
+		Metadata:    s.GetMetadata(),
+		SheetName:   "Zone Mapping",
+		Description: "Logical-to-physical availability zone mappings for Azure regions by subscription",
+		Table:       table,
+	}, nil
+}
+
+// locationResponse represents the API response structure
+type locationResponse struct {
+	Value []locationInfo `json:"value"`
+}
+
+// locationInfo represents a single location with zone mappings
+type locationInfo struct {
+	Name                     *string                   `json:"name"`
+	DisplayName              *string                   `json:"displayName"`
+	AvailabilityZoneMappings []availabilityZoneMapping `json:"availabilityZoneMappings"`
+}
+
+// availabilityZoneMapping represents a logical-to-physical zone mapping
+type availabilityZoneMapping struct {
+	LogicalZone  *string `json:"logicalZone"`
+	PhysicalZone *string `json:"physicalZone"`
+}
+
+// fetchZoneMappings retrieves zone mappings for a single subscription using direct REST API call
+func (s *ZoneMappingScanner) fetchZoneMappings(ctx context.Context, cred azcore.TokenCredential, subscriptionID, subscriptionName string) ([]zoneMappingResult, error) {
+	// Apply throttling to respect ARM API limits
+	_ = throttling.WaitARM(ctx) // nolint:errcheck
+
+	// Create pipeline with authentication
+	clientOptions := policy.ClientOptions{
+		PerCallPolicies: []policy.Policy{
+			runtime.NewBearerTokenPolicy(cred, []string{"https://management.azure.com/.default"}, nil),
+		},
+	}
+	pipeline := runtime.NewPipeline("azqr", "1.0.0", runtime.PipelineOptions{}, &clientOptions)
+
+	// Construct the REST API URL
+	// GET /subscriptions/{subscriptionId}/locations?api-version=2022-12-01
+	endpoint := fmt.Sprintf("https://management.azure.com/subscriptions/%s/locations?api-version=2022-12-01", subscriptionID)
+
+	// Create the request
+	req, err := runtime.NewRequest(ctx, http.MethodGet, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Send the request through the pipeline
+	resp, err := pipeline.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close() // nolint:errcheck
+	}()
+
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse the response
+	var locationsResp locationResponse
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if err := json.Unmarshal(body, &locationsResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	log.Debug().Msgf("Retrieved %d locations for subscription %s", len(locationsResp.Value), subscriptionName)
+
+	// Process the results
+	results := make([]zoneMappingResult, 0)
+	locationsWithZones := 0
+	for _, location := range locationsResp.Value {
+		// Debug: log each location
+		locationName := ""
+		if location.Name != nil {
+			locationName = *location.Name
+		}
+
+		// Only process locations that have availability zone mappings
+		if len(location.AvailabilityZoneMappings) == 0 {
+			log.Debug().Msgf("Location %s has no zone mappings", locationName)
+			continue
+		}
+
+		locationsWithZones++
+		log.Debug().Msgf("Location %s has %d zone mappings", locationName, len(location.AvailabilityZoneMappings))
+
+		displayName := ""
+		if location.DisplayName != nil {
+			displayName = *location.DisplayName
+		}
+
+		// Extract each zone mapping for this location
+		for _, mapping := range location.AvailabilityZoneMappings {
+			logicalZone := ""
+			if mapping.LogicalZone != nil {
+				logicalZone = *mapping.LogicalZone
+			}
+
+			physicalZone := ""
+			if mapping.PhysicalZone != nil {
+				physicalZone = *mapping.PhysicalZone
+			}
+
+			results = append(results, zoneMappingResult{
+				subscriptionID:   subscriptionID,
+				subscriptionName: subscriptionName,
+				location:         locationName,
+				displayName:      displayName,
+				logicalZone:      logicalZone,
+				physicalZone:     physicalZone,
+			})
+		}
+	}
+
+	log.Debug().Msgf("Subscription %s: found %d locations with zones, extracted %d zone mappings", subscriptionName, locationsWithZones, len(results))
+
+	return results, nil
+}
+
+// init registers the plugin automatically
+func init() {
+	plugins.RegisterInternalPlugin("zone-mapping", NewZoneMappingScanner())
+}

--- a/internal/scanners/plugins/zone/types.go
+++ b/internal/scanners/plugins/zone/types.go
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package zone
+
+// zoneMappingResult represents a single logical-to-physical zone mapping for a location
+type zoneMappingResult struct {
+	subscriptionID   string
+	subscriptionName string
+	location         string
+	displayName      string
+	logicalZone      string
+	physicalZone     string
+}


### PR DESCRIPTION
# Description

This pull request introduces a new internal plugin for Azure Quick Review (azqr) called "Zone Mapping," which enables advanced analytics by mapping logical to physical availability zones across Azure subscriptions. It also updates documentation to describe all internal plugins, their features, usage, and output formats, and registers the new plugin in the codebase.

**Internal Plugin System Enhancements**

* Added a new internal plugin, `zone-mapping`, which retrieves logical-to-physical availability zone mappings for all Azure regions in each subscription. The plugin uses parallel processing, direct ARM REST API calls, and returns results in a structured table format for Excel, JSON, and CSV outputs. [[1]](diffhunk://#diff-e513464379fc1fade44323083c16d2959ff6602c5b4ff4b0799eaef465d3e760R1-R246) [[2]](diffhunk://#diff-62908a16475ce49fdb7d8f3955b07eab301e3f00bc5a47e14fcbaa9e7344b354R1-R14)
* Registered the `zone-mapping` plugin in the main application, so it is available via the CLI and plugin system.

**Documentation Updates**

* Updated the main `README.md` to describe the new advanced internal plugins, including "OpenAI Throttling Monitor," "Carbon Emissions Tracking," and "Zone Mapping," with usage examples and links to further documentation.
* Added comprehensive documentation for internal plugins in `docs/content/en/docs/Plugins/internal-plugins.md`, detailing each plugin's features, output columns, permissions, performance, and usage instructions.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #669

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
