### PR TITLE
feat: Add Microsoft Fabric Capacities scanner with associated rules a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ erc | Microsoft.Network/expressRouteCircuits
 erc | Microsoft.Network/ExpressRoutePorts
 evgd | Microsoft.EventGrid/domains
 evh | Microsoft.EventHub/namespaces
+fabric | Microsoft.Fabric/capacities
 fdfp | Microsoft.Network/frontdoorWebApplicationFirewallPolicies
 gal | Microsoft.Compute/galleries
 hpc | Specialized.Workload/HPC

--- a/cmd/azqr/commands/fabric.go
+++ b/cmd/azqr/commands/fabric.go
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	scanCmd.AddCommand(fabricCmd)
+}
+
+var fabricCmd = &cobra.Command{
+	Use:   "fabric",
+	Short: "Scan Microsoft Fabric Capacities",
+	Long:  "Scan Microsoft Fabric Capacities",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		scan(cmd, []string{"fabric"})
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fabric/armfabric v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto v1.3.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid v1.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid v1.0.0/go.mod h1:t8kRpcgm+RdImuJgHG6SfoQ0tpb9LGl7MF1E6u0yeeA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0 h1:4hGvxD72TluuFIXVr8f4XkKZfqAa7Pj61t0jmQ7+kes=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0/go.mod h1:TSH7DcFItwAufy0Lz+Ft2cyopExCpxbOxI5SkH4dRNo=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fabric/armfabric v1.0.0 h1:rSss+KFqv/y2WeWCVjNmfPL1riYJ8dTbE0HqidCowuk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fabric/armfabric v1.0.0/go.mod h1:oiQJZy3KaFouyQYLQow7+Zek9MS885GJ3u8YCmuS9wQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=

--- a/internal/scanner.go
+++ b/internal/scanner.go
@@ -52,6 +52,7 @@ import (
 	_ "github.com/Azure/azqr/internal/scanners/erc"
 	_ "github.com/Azure/azqr/internal/scanners/evgd"
 	_ "github.com/Azure/azqr/internal/scanners/evh"
+	_ "github.com/Azure/azqr/internal/scanners/fabric"
 	_ "github.com/Azure/azqr/internal/scanners/fdfp"
 	_ "github.com/Azure/azqr/internal/scanners/gal"
 	_ "github.com/Azure/azqr/internal/scanners/hpc"

--- a/internal/scanners/fabric/fabric.go
+++ b/internal/scanners/fabric/fabric.go
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package fabric
+
+import (
+	"github.com/Azure/azqr/internal/models"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fabric/armfabric"
+)
+
+func init() {
+	models.ScannerList["fabric"] = []models.IAzureScanner{&FabricScanner{}}
+}
+
+// FabricScanner - Scanner for Microsoft Fabric Capacities
+type FabricScanner struct {
+	config *models.ScannerConfig
+	client *armfabric.CapacitiesClient
+}
+
+// Init - Initializes the FabricScanner
+func (c *FabricScanner) Init(config *models.ScannerConfig) error {
+	c.config = config
+	var err error
+	c.client, err = armfabric.NewCapacitiesClient(config.SubscriptionID, config.Cred, config.ClientOptions)
+	return err
+}
+
+// Scan - Scans all Microsoft Fabric Capacities in a Subscription
+func (c *FabricScanner) Scan(scanContext *models.ScanContext) ([]*models.AzqrServiceResult, error) {
+	models.LogSubscriptionScan(c.config.SubscriptionID, c.ResourceTypes()[0])
+
+	capacities, err := c.listCapacities()
+	if err != nil {
+		if models.ShouldSkipError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	engine := models.RecommendationEngine{}
+	rules := c.GetRecommendations()
+	results := []*models.AzqrServiceResult{}
+
+	for _, capacity := range capacities {
+		rr := engine.EvaluateRecommendations(rules, capacity, scanContext)
+
+		results = append(results, &models.AzqrServiceResult{
+			SubscriptionID:   c.config.SubscriptionID,
+			SubscriptionName: c.config.SubscriptionName,
+			ResourceGroup:    models.GetResourceGroupFromResourceID(*capacity.ID),
+			ServiceName:      *capacity.Name,
+			Type:             *capacity.Type,
+			Location:         *capacity.Location,
+			Recommendations:  rr,
+		})
+	}
+	return results, nil
+}
+
+func (c *FabricScanner) listCapacities() ([]*armfabric.Capacity, error) {
+	pager := c.client.NewListBySubscriptionPager(nil)
+
+	capacities := make([]*armfabric.Capacity, 0)
+	for pager.More() {
+		resp, err := pager.NextPage(c.config.Ctx)
+		if err != nil {
+			return nil, err
+		}
+		capacities = append(capacities, resp.Value...)
+	}
+	return capacities, nil
+}
+
+func (a *FabricScanner) ResourceTypes() []string {
+	return []string{"Microsoft.Fabric/capacities"}
+}

--- a/internal/scanners/fabric/rules.go
+++ b/internal/scanners/fabric/rules.go
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package fabric
+
+import (
+	"strings"
+
+	"github.com/Azure/azqr/internal/models"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fabric/armfabric"
+)
+
+// GetRecommendations - Returns the rules for the FabricScanner
+func (a *FabricScanner) GetRecommendations() map[string]models.AzqrRecommendation {
+	return map[string]models.AzqrRecommendation{
+		"fabric-001": {
+			RecommendationID: "fabric-001",
+			ResourceType:     "Microsoft.Fabric/capacities",
+			Category:         models.CategoryMonitoringAndAlerting,
+			Recommendation:   "Fabric Capacity should have diagnostic settings enabled",
+			Impact:           models.ImpactLow,
+			Eval: func(target interface{}, scanContext *models.ScanContext) (bool, string) {
+				service := target.(*armfabric.Capacity)
+				_, ok := scanContext.DiagnosticsSettings[strings.ToLower(*service.ID)]
+				return !ok, ""
+			},
+			LearnMoreUrl: "https://learn.microsoft.com/en-us/fabric/admin/monitoring-overview",
+		},
+		"fabric-002": {
+			RecommendationID:   "fabric-002",
+			ResourceType:       "Microsoft.Fabric/capacities",
+			Category:           models.CategoryHighAvailability,
+			Recommendation:     "Fabric Capacity should have a SLA",
+			RecommendationType: models.TypeSLA,
+			Impact:             models.ImpactHigh,
+			Eval: func(target interface{}, scanContext *models.ScanContext) (bool, string) {
+				return false, "99.9%"
+			},
+			LearnMoreUrl: "https://www.microsoft.com/licensing/docs/view/Service-Level-Agreements-SLA-for-Online-Services",
+		},
+		"fabric-003": {
+			RecommendationID: "fabric-003",
+			ResourceType:     "Microsoft.Fabric/capacities",
+			Category:         models.CategoryGovernance,
+			Recommendation:   "Fabric Capacity Name should comply with naming conventions",
+			Impact:           models.ImpactLow,
+			Eval: func(target interface{}, scanContext *models.ScanContext) (bool, string) {
+				c := target.(*armfabric.Capacity)
+				caf := strings.HasPrefix(*c.Name, "fc")
+				return !caf, ""
+			},
+			LearnMoreUrl: "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations",
+		},
+		"fabric-004": {
+			RecommendationID: "fabric-004",
+			ResourceType:     "Microsoft.Fabric/capacities",
+			Category:         models.CategoryGovernance,
+			Recommendation:   "Fabric Capacity should have tags defined",
+			Impact:           models.ImpactLow,
+			Eval: func(target interface{}, scanContext *models.ScanContext) (bool, string) {
+				c := target.(*armfabric.Capacity)
+				return len(c.Tags) == 0, ""
+			},
+			LearnMoreUrl: "https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources",
+		},
+		"fabric-005": {
+			RecommendationID: "fabric-005",
+			ResourceType:     "Microsoft.Fabric/capacities",
+			Category:         models.CategoryOtherBestPractices,
+			Recommendation:   "Fabric Capacity should be in Active state",
+			Impact:           models.ImpactMedium,
+			Eval: func(target interface{}, scanContext *models.ScanContext) (bool, string) {
+				c := target.(*armfabric.Capacity)
+				state := ""
+				if c.Properties != nil && c.Properties.State != nil {
+					state = string(*c.Properties.State)
+				}
+				isActive := strings.EqualFold(state, "Active")
+				return !isActive, state
+			},
+			LearnMoreUrl: "https://learn.microsoft.com/en-us/fabric/enterprise/pause-resume",
+		},
+		"fabric-006": {
+			RecommendationID: "fabric-006",
+			ResourceType:     "Microsoft.Fabric/capacities",
+			Category:         models.CategorySecurity,
+			Recommendation:   "Fabric Capacity should have administrators configured",
+			Impact:           models.ImpactMedium,
+			Eval: func(target interface{}, scanContext *models.ScanContext) (bool, string) {
+				c := target.(*armfabric.Capacity)
+				hasAdmins := c.Properties != nil &&
+					c.Properties.Administration != nil &&
+					c.Properties.Administration.Members != nil &&
+					len(c.Properties.Administration.Members) > 0
+				return !hasAdmins, ""
+			},
+			LearnMoreUrl: "https://learn.microsoft.com/en-us/fabric/admin/capacity-settings",
+		},
+	}
+}

--- a/internal/scanners/fabric/rules_test.go
+++ b/internal/scanners/fabric/rules_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package fabric
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azqr/internal/models"
+	"github.com/Azure/azqr/internal/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/fabric/armfabric"
+)
+
+func TestFabricScanner_Rules(t *testing.T) {
+	type fields struct {
+		rule        string
+		target      interface{}
+		scanContext *models.ScanContext
+	}
+	type want struct {
+		broken bool
+		result string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   want
+	}{
+		{
+			name: "FabricScanner DiagnosticSettings",
+			fields: fields{
+				rule: "fabric-001",
+				target: &armfabric.Capacity{
+					ID: to.Ptr("test"),
+				},
+				scanContext: &models.ScanContext{
+					DiagnosticsSettings: map[string]bool{
+						"test": true,
+					},
+				},
+			},
+			want: want{
+				broken: false,
+				result: "",
+			},
+		},
+		{
+			name: "FabricScanner DiagnosticSettings not configured",
+			fields: fields{
+				rule: "fabric-001",
+				target: &armfabric.Capacity{
+					ID: to.Ptr("test"),
+				},
+				scanContext: &models.ScanContext{
+					DiagnosticsSettings: map[string]bool{},
+				},
+			},
+			want: want{
+				broken: true,
+				result: "",
+			},
+		},
+		{
+			name: "FabricScanner SLA",
+			fields: fields{
+				rule:        "fabric-002",
+				target:      &armfabric.Capacity{},
+				scanContext: &models.ScanContext{},
+			},
+			want: want{
+				broken: false,
+				result: "99.9%",
+			},
+		},
+		{
+			name: "FabricScanner CAF compliant",
+			fields: fields{
+				rule: "fabric-003",
+				target: &armfabric.Capacity{
+					Name: to.Ptr("fc-production"),
+				},
+				scanContext: &models.ScanContext{},
+			},
+			want: want{
+				broken: false,
+				result: "",
+			},
+		},
+		{
+			name: "FabricScanner CAF non-compliant",
+			fields: fields{
+				rule: "fabric-003",
+				target: &armfabric.Capacity{
+					Name: to.Ptr("my-fabric-capacity"),
+				},
+				scanContext: &models.ScanContext{},
+			},
+			want: want{
+				broken: true,
+				result: "",
+			},
+		},
+		{
+			name: "FabricScanner Tags defined",
+			fields: fields{
+				rule: "fabric-004",
+				target: &armfabric.Capacity{
+					Tags: map[string]*string{
+						"env": to.Ptr("production"),
+					},
+				},
+				scanContext: &models.ScanContext{},
+			},
+			want: want{
+				broken: false,
+				result: "",
+			},
+		},
+		{
+			name: "FabricScanner Tags not defined",
+			fields: fields{
+				rule: "fabric-004",
+				target: &armfabric.Capacity{
+					Tags: map[string]*string{},
+				},
+				scanContext: &models.ScanContext{},
+			},
+			want: want{
+				broken: true,
+				result: "",
+			},
+		},
+		{
+			name: "FabricScanner Active state",
+			fields: fields{
+				rule: "fabric-005",
+				target: &armfabric.Capacity{
+					Properties: &armfabric.CapacityProperties{
+						State: to.Ptr(armfabric.ResourceStateActive),
+					},
+				},
+				scanContext: &models.ScanContext{},
+			},
+			want: want{
+				broken: false,
+				result: "Active",
+			},
+		},
+		{
+			name: "FabricScanner Paused state",
+			fields: fields{
+				rule: "fabric-005",
+				target: &armfabric.Capacity{
+					Properties: &armfabric.CapacityProperties{
+						State: to.Ptr(armfabric.ResourceStatePaused),
+					},
+				},
+				scanContext: &models.ScanContext{},
+			},
+			want: want{
+				broken: true,
+				result: "Paused",
+			},
+		},
+		{
+			name: "FabricScanner Administrators configured",
+			fields: fields{
+				rule: "fabric-006",
+				target: &armfabric.Capacity{
+					Properties: &armfabric.CapacityProperties{
+						Administration: &armfabric.CapacityAdministration{
+							Members: []*string{
+								to.Ptr("admin@contoso.com"),
+							},
+						},
+					},
+				},
+				scanContext: &models.ScanContext{},
+			},
+			want: want{
+				broken: false,
+				result: "",
+			},
+		},
+		{
+			name: "FabricScanner No administrators",
+			fields: fields{
+				rule: "fabric-006",
+				target: &armfabric.Capacity{
+					Properties: &armfabric.CapacityProperties{
+						Administration: &armfabric.CapacityAdministration{
+							Members: []*string{},
+						},
+					},
+				},
+				scanContext: &models.ScanContext{},
+			},
+			want: want{
+				broken: true,
+				result: "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &FabricScanner{}
+			rules := s.GetRecommendations()
+			b, w := rules[tt.fields.rule].Eval(tt.fields.target, tt.fields.scanContext)
+			got := want{
+				broken: b,
+				result: w,
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FabricScanner Rule.Eval() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Adding new functionality for scanning Fabric capacities in scanned subscriptions, obtaining the capacity type, resource group, region, etc.


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Unit tests passing
