### PR TITLE
fix: ensure build target is explicitly defined in Makefile #707

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ DEBUG_BUILD_TAGS := debug
 
 all: $(TARGET)
 
+build: $(TARGET)
+
 debug: $(TARGET)-debug
 
 help:


### PR DESCRIPTION
# Description

This pull request introduces a new `build` target to the `Makefile`, making it easier to invoke the standard build process using `make build`. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #707 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
