### PR TITLE
feat: add feature toggles for rendering Excel sheets

### DIFF
--- a/internal/renderers/excel/advisor.go
+++ b/internal/renderers/excel/advisor.go
@@ -12,6 +12,12 @@ import (
 )
 
 func renderAdvisor(f *excelize.File, data *renderers.ReportData) {
+	// Skip creating the sheet if the feature is disabled
+	if !data.AdvisorEnabled {
+		log.Info().Msg("Skipping Advisor. Feature is disabled")
+		return
+	}
+
 	_, err := f.NewSheet("Advisor")
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create Advisor sheet")
@@ -21,27 +27,24 @@ func renderAdvisor(f *excelize.File, data *renderers.ReportData) {
 	headers := records[0]
 	createFirstRow(f, "Advisor", headers)
 
-	if len(data.Advisor) > 0 {
-		records = records[1:]
-		currentRow := 4
-		for _, row := range records {
-			currentRow += 1
-			cell, err := excelize.CoordinatesToCellName(1, currentRow)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to get cell")
-			}
-			err = f.SetSheetRow("Advisor", cell, &row)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to set row")
-			}
-		}
+	// Skip if no data to render
+	if len(data.Advisor) == 0 {
+		log.Info().Msg("Skipping Advisor. No data to render")
+	}
 
-		configureSheet(f, "Advisor", headers, currentRow)
-	} else {
-		if !data.AdvisorEnabled {
-			log.Info().Msg("Skipping Advisor. Feature is disabled")
-		} else {
-			log.Info().Msg("Skipping Advisor. No data to render")
+	records = records[1:]
+	currentRow := 4
+	for _, row := range records {
+		currentRow += 1
+		cell, err := excelize.CoordinatesToCellName(1, currentRow)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to get cell")
+		}
+		err = f.SetSheetRow("Advisor", cell, &row)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to set row")
 		}
 	}
+
+	configureSheet(f, "Advisor", headers, currentRow)
 }

--- a/internal/renderers/excel/arc_sql.go
+++ b/internal/renderers/excel/arc_sql.go
@@ -13,6 +13,12 @@ import (
 
 // renderArcSQL creates and populates the Arc SQL sheet in the Excel report.
 func renderArcSQL(f *excelize.File, data *renderers.ReportData) {
+	// Skip creating the sheet if the feature is disabled
+	if !data.ArcEnabled {
+		log.Info().Msg("Skipping Arc SQL. Feature is disabled")
+		return
+	}
+
 	_, err := f.NewSheet("Arc SQL")
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create Arc SQL sheet")
@@ -22,27 +28,24 @@ func renderArcSQL(f *excelize.File, data *renderers.ReportData) {
 	headers := records[0]
 	createFirstRow(f, "Arc SQL", headers)
 
-	if len(data.ArcSQL) > 0 {
-		records = records[1:]
-		currentRow := 4
-		for _, row := range records {
-			currentRow += 1
-			cell, err := excelize.CoordinatesToCellName(1, currentRow)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to get cell")
-			}
-			err = f.SetSheetRow("Arc SQL", cell, &row)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to set row")
-			}
-		}
+	// Skip if no data to render
+	if len(data.ArcSQL) == 0 {
+		log.Info().Msg("Skipping Arc SQL. No data to render")
+	}
 
-		configureSheet(f, "Arc SQL", headers, currentRow)
-	} else {
-		if !data.ArcEnabled {
-			log.Info().Msg("Skipping Arc SQL. Feature is disabled")
-		} else {
-			log.Info().Msg("Skipping Arc SQL. No data to render")
+	records = records[1:]
+	currentRow := 4
+	for _, row := range records {
+		currentRow += 1
+		cell, err := excelize.CoordinatesToCellName(1, currentRow)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to get cell")
+		}
+		err = f.SetSheetRow("Arc SQL", cell, &row)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to set row")
 		}
 	}
+
+	configureSheet(f, "Arc SQL", headers, currentRow)
 }

--- a/internal/renderers/excel/azure_policy.go
+++ b/internal/renderers/excel/azure_policy.go
@@ -13,6 +13,12 @@ import (
 
 // renderAzurePolicy creates and populates the Azure Policy sheet in the Excel report.
 func renderAzurePolicy(f *excelize.File, data *renderers.ReportData) {
+	// Skip creating the sheet if the feature is disabled
+	if !data.PolicyEnabled {
+		log.Info().Msg("Skipping Azure Policy. Feature is disabled")
+		return
+	}
+
 	_, err := f.NewSheet("Azure Policy")
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create Azure Policy sheet")
@@ -22,27 +28,24 @@ func renderAzurePolicy(f *excelize.File, data *renderers.ReportData) {
 	headers := records[0]
 	createFirstRow(f, "Azure Policy", headers)
 
-	if len(data.AzurePolicy) > 0 {
-		records = records[1:]
-		currentRow := 4
-		for _, row := range records {
-			currentRow += 1
-			cell, err := excelize.CoordinatesToCellName(1, currentRow)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to get cell")
-			}
-			err = f.SetSheetRow("Azure Policy", cell, &row)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to set row")
-			}
-		}
+	// Skip if no data to render
+	if len(data.AzurePolicy) == 0 {
+		log.Info().Msg("Skipping Azure Policy. No data to render")
+	}
 
-		configureSheet(f, "Azure Policy", headers, currentRow)
-	} else {
-		if !data.PolicyEnabled {
-			log.Info().Msg("Skipping Azure Policy. Feature is disabled")
-		} else {
-			log.Info().Msg("Skipping Azure Policy. No data to render")
+	records = records[1:]
+	currentRow := 4
+	for _, row := range records {
+		currentRow += 1
+		cell, err := excelize.CoordinatesToCellName(1, currentRow)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to get cell")
+		}
+		err = f.SetSheetRow("Azure Policy", cell, &row)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to set row")
 		}
 	}
+
+	configureSheet(f, "Azure Policy", headers, currentRow)
 }

--- a/internal/renderers/excel/cost.go
+++ b/internal/renderers/excel/cost.go
@@ -12,6 +12,12 @@ import (
 )
 
 func renderCosts(f *excelize.File, data *renderers.ReportData) {
+	// Skip creating the sheet if the feature is disabled
+	if !data.CostEnabled {
+		log.Info().Msg("Skipping Costs. Feature is disabled")
+		return
+	}
+
 	_, err := f.NewSheet("Costs")
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create Costs sheet")
@@ -21,27 +27,24 @@ func renderCosts(f *excelize.File, data *renderers.ReportData) {
 	headers := records[0]
 	createFirstRow(f, "Costs", headers)
 
-	if data.Cost != nil && len(data.Cost.Items) > 0 {
-		records = records[1:]
-		currentRow := 4
-		for _, row := range records {
-			currentRow += 1
-			cell, err := excelize.CoordinatesToCellName(1, currentRow)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to get cell")
-			}
-			err = f.SetSheetRow("Costs", cell, &row)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to set row")
-			}
-		}
+	// Skip if no data to render
+	if data.Cost == nil || len(data.Cost.Items) == 0 {
+		log.Info().Msg("Skipping Costs. No data to render")
+	}
 
-		configureSheet(f, "Costs", headers, currentRow)
-	} else {
-		if !data.CostEnabled {
-			log.Info().Msg("Skipping Costs. Feature is disabled")
-		} else {
-			log.Info().Msg("Skipping Costs. No data to render")
+	records = records[1:]
+	currentRow := 4
+	for _, row := range records {
+		currentRow += 1
+		cell, err := excelize.CoordinatesToCellName(1, currentRow)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to get cell")
+		}
+		err = f.SetSheetRow("Costs", cell, &row)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to set row")
 		}
 	}
+
+	configureSheet(f, "Costs", headers, currentRow)
 }

--- a/internal/renderers/excel/defender.go
+++ b/internal/renderers/excel/defender.go
@@ -12,6 +12,12 @@ import (
 )
 
 func renderDefender(f *excelize.File, data *renderers.ReportData) {
+	// Skip creating the sheet if the feature is disabled
+	if !data.DefenderEnabled {
+		log.Info().Msg("Skipping Defender. Feature is disabled")
+		return
+	}
+
 	_, err := f.NewSheet("Defender")
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create Defender sheet")
@@ -21,33 +27,36 @@ func renderDefender(f *excelize.File, data *renderers.ReportData) {
 	headers := records[0]
 	createFirstRow(f, "Defender", headers)
 
-	if len(data.Defender) > 0 {
-		records = records[1:]
-		currentRow := 4
-		for _, row := range records {
-			currentRow += 1
-			cell, err := excelize.CoordinatesToCellName(1, currentRow)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to get cell")
-			}
-			err = f.SetSheetRow("Defender", cell, &row)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to set row")
-			}
-		}
+	// Skip if no data to render
+	if len(data.Defender) == 0 {
+		log.Info().Msg("Skipping Defender. No data to render")
+	}
 
-		configureSheet(f, "Defender", headers, currentRow)
-	} else {
-		if !data.DefenderEnabled {
-			log.Info().Msg("Skipping Defender. Feature is disabled")
-		} else {
-			log.Info().Msg("Skipping Defender. No data to render")
+	records = records[1:]
+	currentRow := 4
+	for _, row := range records {
+		currentRow += 1
+		cell, err := excelize.CoordinatesToCellName(1, currentRow)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to get cell")
+		}
+		err = f.SetSheetRow("Defender", cell, &row)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to set row")
 		}
 	}
+
+	configureSheet(f, "Defender", headers, currentRow)
 }
 
 // renderDefenderRecommendations renders the Defender recommendations to the Excel sheet.
 func renderDefenderRecommendations(f *excelize.File, data *renderers.ReportData) {
+	// Skip creating the sheet if the feature is disabled
+	if !data.DefenderEnabled {
+		log.Info().Msg("Skipping DefenderRecommendations. Feature is disabled")
+		return
+	}
+
 	sheetName := "DefenderRecommendations"
 	_, err := f.NewSheet(sheetName)
 	if err != nil {
@@ -58,28 +67,26 @@ func renderDefenderRecommendations(f *excelize.File, data *renderers.ReportData)
 	headers := records[0]
 	createFirstRow(f, sheetName, headers)
 
-	if len(data.DefenderRecommendations) > 0 {
-		records = records[1:]
-		currentRow := 4
-		for _, row := range records {
-			currentRow += 1
-			cell, err := excelize.CoordinatesToCellName(1, currentRow)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to get cell")
-			}
-			err = f.SetSheetRow(sheetName, cell, &row)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Failed to set row")
-			}
-			setHyperLink(f, sheetName, 11, currentRow)
-		}
-
-		configureSheet(f, sheetName, headers, currentRow)
-	} else {
-		if !data.DefenderEnabled {
-			log.Info().Msg("Skipping DefenderRecommendations. Feature is disabled")
-		} else {
-			log.Info().Msg("Skipping DefenderRecommendations. No data to render")
-		}
+	// Skip if no data to render
+	if len(data.DefenderRecommendations) == 0 {
+		log.Info().Msg("Skipping DefenderRecommendations. No data to render")
+		return
 	}
+
+	records = records[1:]
+	currentRow := 4
+	for _, row := range records {
+		currentRow += 1
+		cell, err := excelize.CoordinatesToCellName(1, currentRow)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to get cell")
+		}
+		err = f.SetSheetRow(sheetName, cell, &row)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to set row")
+		}
+		setHyperLink(f, sheetName, 11, currentRow)
+	}
+
+	configureSheet(f, sheetName, headers, currentRow)
 }

--- a/internal/viewer/static/app.js
+++ b/internal/viewer/static/app.js
@@ -106,6 +106,18 @@ async function initNav() {
     const nav = document.getElementById('nav');
     let html = '';
 
+    // Fetch available datasets first
+    let availableDatasets = [];
+    try {
+        availableDatasets = await fetchJSON('/api/datasets');
+        console.log('Available datasets:', availableDatasets);
+    } catch (error) {
+        console.error('Error fetching datasets:', error);
+    }
+
+    // Check which routes have data
+    const hasData = (route) => availableDatasets.includes(route);
+
     menuStructure.forEach(section => {
         if (section.route) {
             // Single item (like Home)
@@ -115,18 +127,24 @@ async function initNav() {
 				</a>
 			</li>`;
         } else if (section.children && section.children.length > 0) {
-            // Group with children - use Bootstrap dropdown
-            html += `<li class="nav-item dropdown">
-				<a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
-					${getMenuIcon(section.label)} ${section.label}
-				</a>
-				<ul class="dropdown-menu">`;
-            section.children.forEach(child => {
-                html += `<li><a class="dropdown-item" href="#${child.route}" onclick="closeMenu()">
-					${getMenuIcon(child.label)} ${child.label}
-				</a></li>`;
-            });
-            html += `</ul></li>`;
+            // Filter children to only those with data
+            const availableChildren = section.children.filter(child => hasData(child.route));
+
+            // Only render the section if it has children with data
+            if (availableChildren.length > 0) {
+                // Group with children - use Bootstrap dropdown
+                html += `<li class="nav-item dropdown">
+					<a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+						${getMenuIcon(section.label)} ${section.label}
+					</a>
+					<ul class="dropdown-menu">`;
+                availableChildren.forEach(child => {
+                    html += `<li><a class="dropdown-item" href="#${child.route}" onclick="closeMenu()">
+						${getMenuIcon(child.label)} ${child.label}
+					</a></li>`;
+                });
+                html += `</ul></li>`;
+            }
         }
     });
 


### PR DESCRIPTION
# Description

This pull request refactors the Excel report rendering logic to improve feature toggling and data presence checks for multiple report sections. It ensures that Excel sheets are only created when their corresponding features are enabled and there is data to render, and logs clear messages when a section is skipped. Additionally, it enhances the web viewer navigation to only display menu items for datasets that are actually available.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
