### PR TITLE
refactor: update HttpClient to use options for better configurability and testing

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -54,7 +54,7 @@ type QueryResponse struct {
 // NewGraphQuery creates a new GraphQuery using the provided TokenCredential.
 func NewGraphQuery(cred azcore.TokenCredential) *GraphQueryClient {
 	// Create Azure HTTP client with built-in retry and throttling
-	httpClient := az.NewHttpClient(cred, 60*time.Second)
+	httpClient := az.NewHttpClient(cred, az.DefaultHttpClientOptions(60*time.Second))
 
 	resourceManagerEndpoint := az.GetResourceManagerEndpoint()
 

--- a/internal/scanners/diagnostics_settings.go
+++ b/internal/scanners/diagnostics_settings.go
@@ -109,7 +109,7 @@ type DiagnosticSettingsScanner struct {
 func (d *DiagnosticSettingsScanner) Init(ctx context.Context, cred azcore.TokenCredential, options *arm.ClientOptions) error {
 	d.ctx = ctx
 	// Create HTTP client with built-in retry logic, authentication, and throttling
-	d.httpClient = az.NewHttpClient(cred, 60*time.Second)
+	d.httpClient = az.NewHttpClient(cred, az.DefaultHttpClientOptions(60*time.Second))
 	return nil
 }
 

--- a/internal/scanners/plugins/zone/mapping.go
+++ b/internal/scanners/plugins/zone/mapping.go
@@ -147,7 +147,7 @@ type availabilityZoneMapping struct {
 // fetchZoneMappings retrieves zone mappings for a single subscription using az.HttpClient
 func (s *ZoneMappingScanner) fetchZoneMappings(ctx context.Context, cred azcore.TokenCredential, subscriptionID, subscriptionName string) ([]zoneMappingResult, error) {
 	// Create HTTP client with authentication and retry capabilities
-	httpClient := az.NewHttpClient(cred, 30*time.Second)
+	httpClient := az.NewHttpClient(cred, az.DefaultHttpClientOptions(30*time.Second))
 
 	// Construct the REST API URL
 	// GET /subscriptions/{subscriptionId}/locations?api-version=2022-12-01
@@ -155,7 +155,7 @@ func (s *ZoneMappingScanner) fetchZoneMappings(ctx context.Context, cred azcore.
 
 	// Make the request with authentication (empty string uses default scope)
 	emptyScope := ""
-	body, err := httpClient.Do(ctx, endpoint, &emptyScope, 3)
+	body, err := httpClient.Do(ctx, endpoint, &emptyScope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch locations: %w", err)
 	}


### PR DESCRIPTION
# Description

This pull request refactors the Azure HTTP client to make its retry and timeout behavior configurable via a new `HttpClientOptions` struct, improving flexibility and testability. It updates all call sites and tests to use the new options, and adds tests for the new configuration logic.

**HttpClient configuration improvements:**

* Introduced `HttpClientOptions` struct to allow configuration of timeout, retry count, and retry delays for the Azure HTTP client. The `NewHttpClient` function now accepts these options, or uses sensible defaults if `nil` is passed. (`internal/az/http_client.go` [internal/az/http_client.goL26-R56](diffhunk://#diff-fe608319f42de82df5561648832dd1ee395ce1d92bfa0f8074d2acb77c848ab4L26-R56))
* Added `DefaultHttpClientOptions` helper for production defaults and updated all usages to construct clients with options instead of raw timeouts. (`internal/az/http_client.go` [[1]](diffhunk://#diff-fe608319f42de82df5561648832dd1ee395ce1d92bfa0f8074d2acb77c848ab4L26-R56) [[2]](diffhunk://#diff-a918a3cf9f028a70ef671823b8aab0bd9c7862aa755f4486a1c2aac013cc497bL57-R57) [[3]](diffhunk://#diff-37218a110408d4f07c4651f417509b9dd4c680516849d35cb15710efffdbe667L112-R112) [[4]](diffhunk://#diff-e513464379fc1fade44323083c16d2959ff6602c5b4ff4b0799eaef465d3e760L150-R158)

**API simplification:**

* Simplified the `Do` method signature by removing the `maxRetries` parameter, as retries are now configured via `HttpClientOptions`. (`internal/az/http_client.go` [[1]](diffhunk://#diff-fe608319f42de82df5561648832dd1ee395ce1d92bfa0f8074d2acb77c848ab4L70-R93) [[2]](diffhunk://#diff-e513464379fc1fade44323083c16d2959ff6602c5b4ff4b0799eaef465d3e760L150-R158)

**Testing enhancements:**

* Added `testHttpClientOptions` for faster, deterministic retries in tests, and refactored all tests to use the new options-based client API. (`internal/az/http_client_test.go` [[1]](diffhunk://#diff-3eaf8c059a9f1b7e2c6b79d31d0fb895f52f753f97d5e05e31cf3c562b8b8643R34-R43) [[2]](diffhunk://#diff-3eaf8c059a9f1b7e2c6b79d31d0fb895f52f753f97d5e05e31cf3c562b8b8643L44-R57) [[3]](diffhunk://#diff-3eaf8c059a9f1b7e2c6b79d31d0fb895f52f753f97d5e05e31cf3c562b8b8643L74-R88) [[4]](diffhunk://#diff-3eaf8c059a9f1b7e2c6b79d31d0fb895f52f753f97d5e05e31cf3c562b8b8643L98-R113) [[5]](diffhunk://#diff-3eaf8c059a9f1b7e2c6b79d31d0fb895f52f753f97d5e05e31cf3c562b8b8643L121-R131)
* Added new tests to verify client creation with `nil` options and to validate the default options logic. (`internal/az/http_client_test.go` [internal/az/http_client_test.goR143-R168](diffhunk://#diff-3eaf8c059a9f1b7e2c6b79d31d0fb895f52f753f97d5e05e31cf3c562b8b8643R143-R168))

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #730

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
