### PR TITLE
fix: update resourceType field to use subscriptionName instead of subscription

### DIFF
--- a/internal/viewer/static/app.js
+++ b/internal/viewer/static/app.js
@@ -489,7 +489,7 @@ function renderTable(rows, datasetName) {
         'azurePolicy': ['subscriptionId', 'subscriptionName', 'resourceGroup', 'resourceType', 'resourceName', 'policyDisplayName', 'policyDescription', 'resourceId', 'timeStamp', 'policyDefinitionName', 'policyDefinitionId', 'policyAssignmentName', 'policyAssignmentId', 'complianceState'],
         'arcSQL': ['subscriptionId', 'subscriptionName', 'azureArcServer', 'sqlInstance', 'resourceGroup', 'version', 'build', 'patchLevel', 'edition', 'vCores', 'dpsStatus', 'license', 'telStatus', 'defenderStatus'],
         'recommendations': ['implemented', 'numberOfImpactedResources', 'azureServiceWellArchitected', 'recommendationSource', 'azureServiceCategoryWellArchitectedArea', 'azureServiceWellArchitectedTopic', 'category', 'recommendation', 'impact', 'bestPracticesGuidance', 'readMore', 'recommendationId'],
-        'resourceType': ['subscription', 'resourceType', 'numberOfResources'],
+        'resourceType': ['subscriptionName', 'resourceType', 'numberOfResources'],
         'defenderRecommendations': ['subscriptionId', 'subscriptionName', 'resourceGroup', 'resourceType', 'resourceName', 'category', 'recommendationSeverity', 'recommendationName', 'actionDescription', 'remediationDescription', 'resourceId'],
         'inventory': ['subscriptionId', 'resourceGroup', 'location', 'resourceType', 'resourceName', 'skuName', 'skuTier', 'kind', 'sla', 'resourceId'],
         'outOfScope': ['subscriptionId', 'resourceGroup', 'location', 'resourceType', 'resourceName', 'resourceId']
@@ -519,7 +519,7 @@ function renderTable(rows, datasetName) {
             'defenderRecommendations': ['subscriptionId', 'subscriptionName', 'resourceGroup', 'resourceType', 'resourceName', 'category', 'recommendationSeverity'],
             'inventory': ['subscriptionId', 'resourceGroup', 'location', 'resourceType', 'resourceName'],
             'outOfScope': ['subscriptionId', 'resourceGroup', 'location', 'resourceType', 'resourceName'],
-            'resourceType': ['subscription', 'resourceType'],
+            'resourceType': ['subscriptionName', 'resourceType'],
             'advisor': ['subscriptionId', 'subscriptionName', 'resourceType', 'resourceName', 'category', 'impact', 'recommendationId'],
             'impacted': ['source', 'category', 'impact', 'resourceType', 'recommendationId', 'subscriptionId', 'subscriptionName', 'resourceGroup', 'resourceName'],
             'recommendations': ['recommendationId', 'subscriptionId', 'subscriptionName', 'resourceGroup', 'resourceName', 'implemented', 'recommendationSource', 'azureServiceCategoryWellArchitectedArea', 'azureServiceWellArchitectedTopic', 'category', 'impact']


### PR DESCRIPTION
# Description

This pull request makes a minor update to the table rendering logic in `internal/viewer/static/app.js` by renaming the `subscription` column to `subscriptionName` for the `resourceType` dataset. This change ensures consistency in column naming across the application.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #786

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
