### PR TITLE
feat: enhance MCP server functionality with version support and fixed file URI handling

### DIFF
--- a/cmd/azqr/commands/mcpserver.go
+++ b/cmd/azqr/commands/mcpserver.go
@@ -36,6 +36,6 @@ Examples:
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		mode := mcpserver.ServerMode(mcpMode)
-		mcpserver.StartWithMode(mode, mcpAddr)
+		mcpserver.StartWithMode(mode, mcpAddr, version)
 	},
 }

--- a/internal/mcpserver/roots.go
+++ b/internal/mcpserver/roots.go
@@ -6,36 +6,58 @@ package mcpserver
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-func currentWorkspace(ctx context.Context) string {
-	result, err := s.RequestRoots(ctx, mcp.ListRootsRequest{})
-	if err == nil {
+// fileURIToPath converts a file:// URI to a local filesystem path.
+// It handles both Unix paths (file:///home/user) and Windows paths
+// (file:///C:/Users, file:///c%3A/Users), decoding percent-encoded characters.
+func fileURIToPath(uri string) string {
+	if !strings.HasPrefix(uri, "file://") {
+		return uri
+	}
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		// Fallback: strip "file://" and hope for the best
+		return strings.TrimPrefix(uri, "file://")
+	}
+
+	// url.Parse decodes percent-encoded characters (e.g. %3A → :) in u.Path.
+	path := u.Path
+
+	// On Windows, MCP clients emit file:///C:/... so the parsed path is /C:/...
+	// Strip the leading "/" before a Windows drive letter to get a valid path.
+	if len(path) >= 3 && path[0] == '/' && isASCIILetter(path[1]) && path[2] == ':' {
+		path = path[1:]
+	}
+
+	return path
+}
+
+// isASCIILetter reports whether b is an ASCII letter (a–z or A–Z).
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// getCurrentFolder returns the first file:// root reported by the MCP client,
+// or falls back to the process working directory.
+func getCurrentFolder(ctx context.Context) (string, error) {
+	if result, err := s.RequestRoots(ctx, mcp.ListRootsRequest{}); err == nil {
 		for _, root := range result.Roots {
-			uri := root.URI
-			if strings.HasPrefix(uri, "file://") {
-				return strings.TrimPrefix(uri, "file://")
+			if strings.HasPrefix(root.URI, "file://") {
+				return fileURIToPath(root.URI), nil
 			}
 		}
 	}
 
-	return ""
-}
-
-func getCurrentFolder(ctx context.Context) (string, error) {
-	currentDir := currentWorkspace(ctx)
-
-	if currentDir != "" {
-		return currentDir, nil
-	}
-
-	currentDir, err := os.Getwd()
+	dir, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current working directory: %w", err)
 	}
-	return currentDir, nil
+	return dir, nil
 }

--- a/internal/mcpserver/roots_tests.go
+++ b/internal/mcpserver/roots_tests.go
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package mcpserver
+
+import "testing"
+
+func TestFileURIToPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// ── Unix paths ──────────────────────────────────────────────────────
+		{
+			name:  "unix three-slash URI",
+			input: "file:///home/user/workspace",
+			want:  "/home/user/workspace",
+		},
+		{
+			name:  "unix three-slash URI with subdirectory",
+			input: "file:///var/log/ghqr",
+			want:  "/var/log/ghqr",
+		},
+
+		// ── Windows paths (uppercase drive letter) ──────────────────────────
+		{
+			name:  "windows three-slash URI uppercase drive",
+			input: "file:///C:/Users/gh/workspace",
+			want:  "C:/Users/gh/workspace",
+		},
+		{
+			name:  "windows three-slash URI uppercase Z drive",
+			input: "file:///Z:/Projects",
+			want:  "Z:/Projects",
+		},
+
+		// ── Windows paths (lowercase drive letter) ──────────────────────────
+		{
+			name:  "windows three-slash URI lowercase drive",
+			input: "file:///c:/Users/gh/workspace",
+			want:  "c:/Users/gh/workspace",
+		},
+
+		// ── Windows paths with percent-encoded colon (%3A) ──────────────────
+		// VS Code sends file:///c%3A/Users/... per Issue 1.
+		{
+			name:  "windows percent-encoded colon lowercase",
+			input: "file:///c%3A/Users/gh/workspace",
+			want:  "c:/Users/gh/workspace",
+		},
+		{
+			name:  "windows percent-encoded colon uppercase",
+			input: "file:///C%3A/Users/gh/workspace",
+			want:  "C:/Users/gh/workspace",
+		},
+
+		// ── Paths that are not file URIs ──────────────────────────────────
+		{
+			name:  "plain path passthrough",
+			input: "C:/Users/gh",
+			want:  "C:/Users/gh",
+		},
+		{
+			name:  "unix plain path passthrough",
+			input: "/home/user",
+			want:  "/home/user",
+		},
+
+		// ── Edge cases ───────────────────────────────────────────────────────
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "file URI with spaces (percent-encoded)",
+			input: "file:///home/user/my%20project",
+			want:  "/home/user/my project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fileURIToPath(tt.input)
+			if got != tt.want {
+				t.Errorf("fileURIToPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsASCIILetter(t *testing.T) {
+	for b := byte('a'); b <= 'z'; b++ {
+		if !isASCIILetter(b) {
+			t.Errorf("isASCIILetter(%q) = false, want true", b)
+		}
+	}
+
+	for b := byte('A'); b <= 'Z'; b++ {
+		if !isASCIILetter(b) {
+			t.Errorf("isASCIILetter(%q) = false, want true", b)
+		}
+	}
+
+	nonLetters := []byte{'0', '9', ':', '/', '\\', ' ', '-', '_'}
+	for _, b := range nonLetters {
+		if isASCIILetter(b) {
+			t.Errorf("isASCIILetter(%q) = true, want false", b)
+		}
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -22,10 +22,15 @@ const (
 // StartWithMode starts the MCP server with the specified mode and address
 // mode: "stdio" for standard input/output, "http" for HTTP/SSE
 // addr: address to listen on (only used for HTTP mode, e.g., ":8080")
-func StartWithMode(mode ServerMode, addr string) {
+// version: version of the MCP server
+func StartWithMode(mode ServerMode, addr, version string) {
+	if version == "" {
+		version = "dev"
+	}
+	
 	s = server.NewMCPServer(
 		"Azure Quick Review 🚀",
-		"0.1.0",
+		version,
 		server.WithToolCapabilities(true), // Enable tool notifications
 		server.WithResourceCapabilities(true, true),
 		server.WithPromptCapabilities(true),

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -135,6 +135,8 @@ func withBasicOptions(opts ...mcp.ToolOption) []mcp.ToolOption {
 			mcp.DefaultBool(true),
 			mcp.Description("Mask sensitive data in output (default: true)."),
 		),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
 	}
 	return append(opts, basicOpts...)
 }


### PR DESCRIPTION
# Description

This pull request introduces improvements to MCP server handling and path parsing, as well as enhancements to tool option annotations. The most significant changes are the addition of robust file URI parsing for cross-platform compatibility, passing the server version dynamically, and expanding test coverage for new path parsing logic.

**MCP server improvements:**

* Added support for passing the MCP server version dynamically to `StartWithMode`, defaulting to `"dev"` if not provided. This ensures the server reports the correct version in its metadata. (`internal/mcpserver/server.go`, `cmd/azqr/commands/mcpserver.go`) [[1]](diffhunk://#diff-4ff2cee6b3a3746623724c28b0012ab458c97dbfaa60f59cb26afda05456b2a7L25-R33) [[2]](diffhunk://#diff-c72d5c22accdfecd12c4e0e754d4eb469ea2775cca19f0e878cd6c1dc7c6901cL39-R39)

**Path parsing enhancements:**

* Introduced the `fileURIToPath` function to reliably convert `file://` URIs to local filesystem paths, handling Unix, Windows (including percent-encoded drive letters), and edge cases. Also added the helper `isASCIILetter`. (`internal/mcpserver/roots.go`)
* Updated `getCurrentFolder` to use the new `fileURIToPath` function, improving cross-platform folder detection from MCP roots. (`internal/mcpserver/roots.go`)

**Testing improvements:**

* Added comprehensive unit tests for `fileURIToPath` and `isASCIILetter` to verify correctness across a variety of URI formats and edge cases. (`internal/mcpserver/roots_tests.go`)

**Tool option enhancements:**

* Added `mcp.WithReadOnlyHintAnnotation(false)` and `mcp.WithDestructiveHintAnnotation(false)` to tool options, improving annotation support for tool capabilities. (`internal/mcpserver/tools.go`)

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
