### PR TITLE
fix(graph): enhance error handling in Resource Graph queries and add support for unsupported logical tables #847

### DIFF
--- a/internal/az/http_client.go
+++ b/internal/az/http_client.go
@@ -4,6 +4,7 @@
 package az
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -131,25 +132,25 @@ func (c *HttpClient) doRequest(ctx context.Context, method, url string, body io.
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to execute request: %w", err)
 	}
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil {
-			log.Warn().Err(closeErr).Msg("Failed to close response body")
-		}
-	}()
 
 	// Read response body
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("Failed to close response body")
+		}
 		return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		log.Warn().Err(closeErr).Msg("Failed to close response body")
 	}
 
 	// Check status code
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return respBody, resp, &HTTPError{
-			StatusCode: resp.StatusCode,
-			Body:       string(respBody),
-			URL:        url,
-		}
+		// Restore body so runtime.NewResponseError can parse error details from payload.
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		return respBody, resp, runtime.NewResponseError(resp)
 	}
 
 	log.Debug().Msgf("Successfully executed %s request to %s (status: %d)", method, url, resp.StatusCode)

--- a/internal/az/http_client_test.go
+++ b/internal/az/http_client_test.go
@@ -5,6 +5,7 @@ package az
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -100,11 +101,11 @@ func TestDo_WithAuth(t *testing.T) {
 	}
 }
 
-func TestDo_HTTPError(t *testing.T) {
+func TestDo_ResponseError(t *testing.T) {
 	// Create a test server that returns an error (TLS required)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error": "internal server error"}`))
+		_, _ = w.Write([]byte(`{"error": {"code": "InternalError", "message": "internal server error"}}`))
 	}))
 	defer server.Close()
 
@@ -121,13 +122,17 @@ func TestDo_HTTPError(t *testing.T) {
 		t.Fatal("Expected an error, got nil")
 	}
 
-	httpErr, ok := err.(*HTTPError)
-	if !ok {
-		t.Fatalf("Expected HTTPError, got %T", err)
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("Expected azcore.ResponseError, got %T", err)
 	}
 
-	if httpErr.StatusCode != http.StatusInternalServerError {
-		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, httpErr.StatusCode)
+	if respErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, respErr.StatusCode)
+	}
+
+	if respErr.ErrorCode != "InternalError" {
+		t.Errorf("Expected error code InternalError, got %s", respErr.ErrorCode)
 	}
 }
 

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -66,7 +66,7 @@ func NewGraphQuery(cred azcore.TokenCredential) *GraphQueryClient {
 
 // Query executes a Resource Graph query for the given subscriptions and query string.
 // It handles batching and pagination.
-func (q *GraphQueryClient) Query(ctx context.Context, query string, subscriptions []*string) *GraphResult {
+func (q *GraphQueryClient) Query(ctx context.Context, query string, subscriptions []*string) (*GraphResult, error) {
 	result := GraphResult{
 		Data: make([]interface{}, 0, 5000),
 	}
@@ -101,18 +101,17 @@ func (q *GraphQueryClient) Query(ctx context.Context, query string, subscription
 			}
 
 			resp, err := q.doRequest(ctx, request)
-			if err == nil {
-				result.Data = append(result.Data, resp.Data...)
-				skipToken = resp.SkipToken
-				log.Debug().Msgf("Graph query batch %d-%d returned %d records, next skipToken: %v", i, j, len(resp.Data), skipToken)
-			} else {
-				log.Fatal().Err(err).Msgf("Failed to run Resource Graph query: %s", query)
-				return nil
+			if err != nil {
+				return nil, fmt.Errorf("failed to run resource graph query: %w", err)
 			}
+
+			result.Data = append(result.Data, resp.Data...)
+			skipToken = resp.SkipToken
+			log.Debug().Msgf("Graph query batch %d-%d returned %d records, next skipToken: %v", i, j, len(resp.Data), skipToken)
 		}
 	}
 	log.Debug().Msgf("Graph query returned %d records", len(result.Data))
-	return &result
+	return &result, nil
 }
 
 // doRequest sends the HTTP request to the Resource Graph API and returns the response.

--- a/internal/graph/graph_scanner.go
+++ b/internal/graph/graph_scanner.go
@@ -4,8 +4,13 @@
 package graph
 
 import (
+	"bytes"
 	"context"
 	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"io/fs"
 	"math"
 	"strings"
@@ -253,6 +258,16 @@ func (a *GraphScanner) worker(ctx context.Context, graph *GraphQueryClient, subs
 		models.LogGraphRecommendationScan(r.ResourceType, r.RecommendationID)
 		res, err := a.graphScan(ctx, graph, r, subscriptions)
 		if err != nil {
+			if shouldSkipUnsupportedGraphLogicalTableError(err) {
+				log.Warn().
+					Err(err).
+					Str("recommendationId", r.RecommendationID).
+					Str("resourceType", r.ResourceType).
+					Msg("Skipping recommendation due to unsupported resource graph logical table")
+				results <- []*models.GraphResult{}
+				wg.Done()
+				continue
+			}
 			log.Fatal().Err(err).Msg("Failed to scan")
 		}
 		results <- res
@@ -268,7 +283,11 @@ func (a *GraphScanner) graphScan(ctx context.Context, graphClient *GraphQueryCli
 	}
 
 	if rule.GraphQuery != "" {
-		result := graphClient.Query(ctx, rule.GraphQuery, subs)
+		result, err := graphClient.Query(ctx, rule.GraphQuery, subs)
+		if err != nil {
+			return nil, fmt.Errorf("recommendation %s query failed: %w", rule.RecommendationID, err)
+		}
+
 		if result.Data != nil {
 			for _, row := range result.Data {
 				m := row.(map[string]interface{})
@@ -351,4 +370,78 @@ func (a *GraphScanner) getGraphRules(service string, rec map[string]map[string]m
 	}
 
 	return r
+}
+
+func shouldSkipUnsupportedGraphLogicalTableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return isUnsupportedLogicalTableErrorMessage(err.Error())
+	}
+
+	if strings.EqualFold(respErr.ErrorCode, "DisallowedLogicalTableName") {
+		return true
+	}
+
+	errMsg := respErr.Error()
+	if isUnsupportedLogicalTableErrorMessage(errMsg) {
+		return true
+	}
+
+	if respErr.RawResponse == nil || respErr.RawResponse.Body == nil {
+		return false
+	}
+
+	body, readErr := io.ReadAll(respErr.RawResponse.Body)
+	if readErr != nil {
+		return false
+	}
+
+	// Restore body so other consumers can still inspect it.
+	respErr.RawResponse.Body = io.NopCloser(bytes.NewReader(body))
+
+	var payload struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Details []struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+
+	if unmarshalErr := json.Unmarshal(body, &payload); unmarshalErr != nil {
+		return false
+	}
+
+	if strings.EqualFold(payload.Error.Code, "DisallowedLogicalTableName") {
+		return true
+	}
+
+	for _, detail := range payload.Error.Details {
+		if strings.EqualFold(detail.Code, "DisallowedLogicalTableName") {
+			return true
+		}
+
+		if isUnsupportedLogicalTableErrorMessage(detail.Message) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isUnsupportedLogicalTableErrorMessage(message string) bool {
+	msg := strings.ToLower(message)
+
+	if strings.Contains(msg, "disallowedlogicaltablename") {
+		return true
+	}
+
+	return strings.Contains(msg, "invalid, unsupported or disallowed") &&
+		strings.Contains(msg, "logical table")
 }

--- a/internal/graph/graph_scanner_test.go
+++ b/internal/graph/graph_scanner_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package graph
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestShouldSkipUnsupportedGraphLogicalTableError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name: "DisallowedLogicalTableName",
+			err: &azcore.ResponseError{
+				ErrorCode: "DisallowedLogicalTableName",
+			},
+			expected: true,
+		},
+		{
+			name: "different response error code",
+			err: &azcore.ResponseError{
+				ErrorCode: "BadRequest",
+			},
+			expected: false,
+		},
+		{
+			name: "nested details DisallowedLogicalTableName",
+			err: &azcore.ResponseError{
+				ErrorCode: "BadRequest",
+				RawResponse: &http.Response{
+					Body: io.NopCloser(bytes.NewReader([]byte(`{"error":{"code":"BadRequest","message":"support info","details":[{"code":"DisallowedLogicalTableName","message":"Table appserviceresources is invalid, unsupported or disallowed."}]}}`))),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "nested details unrelated error",
+			err: &azcore.ResponseError{
+				ErrorCode: "BadRequest",
+				RawResponse: &http.Response{
+					Body: io.NopCloser(bytes.NewReader([]byte(`{"error":{"code":"BadRequest","message":"support info","details":[{"code":"OtherCode","message":"some other failure"}]}}`))),
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "generic error with disallowed logical table code",
+			err:      errors.New(`recommendation 0b80b67c-afbe-4988-ad58-a85a146b681e query failed: failed to run resource graph query: HTTP 400 from https://management.chinacloudapi.cn/providers/Microsoft.ResourceGraph/resources?api-version=2024-04-01: {"error":{"code":"BadRequest","message":"support info","details":[{"code":"DisallowedLogicalTableName","message":"Table appserviceresources is invalid, unsupported or disallowed."}]}}`),
+			expected: true,
+		},
+		{
+			name:     "generic error with unsupported-table message only",
+			err:      errors.New("Table appserviceresources is invalid, unsupported or disallowed."),
+			expected: false,
+		},
+		{
+			name:     "generic error with logical table message",
+			err:      errors.New("Logical table appserviceresources is invalid, unsupported or disallowed."),
+			expected: true,
+		},
+		{
+			name:     "non-response error",
+			err:      errors.New("generic error"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldSkipUnsupportedGraphLogicalTableError(tt.err)
+			if got != tt.expected {
+				t.Errorf("ShouldSkipUnsupportedGraphLogicalTableError() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/scanners/advisor.go
+++ b/internal/scanners/advisor.go
@@ -75,7 +75,11 @@ func (s *AdvisorScanner) Scan(ctx context.Context, cred azcore.TokenCredential, 
 		category         string
 	}
 
-	result := graphClient.Query(ctx, query, subs)
+	result, err := graphClient.Query(ctx, query, subs)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to query Azure Resource Graph for Advisor recommendations")
+		return nil
+	}
 	resources := []*models.AdvisorResult{}
 	seen := make(map[advisorKey]struct{}, len(result.Data))
 	if result.Data != nil {

--- a/internal/scanners/arc_sql.go
+++ b/internal/scanners/arc_sql.go
@@ -55,7 +55,11 @@ func (s *ArcSQLScanner) Scan(ctx context.Context, cred azcore.TokenCredential, s
 	for s := range subscriptions {
 		subs = append(subs, to.Ptr(s))
 	}
-	result := graphClient.Query(ctx, query, subs)
+	result, err := graphClient.Query(ctx, query, subs)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to query Azure Resource Graph for Arc SQL resources")
+		return nil
+	}
 	resources := []*models.ArcSQLResult{}
 
 	if result.Data != nil {

--- a/internal/scanners/azure_policy.go
+++ b/internal/scanners/azure_policy.go
@@ -59,7 +59,11 @@ func (s *AzurePolicyScanner) Scan(ctx context.Context, cred azcore.TokenCredenti
 		policyDefinitionID string
 	}
 
-	result := graphClient.Query(ctx, query, subs)
+	result, err := graphClient.Query(ctx, query, subs)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to query Azure Resource Graph for Azure Policy non-compliant resources")
+		return nil
+	}
 	resources := []*models.AzurePolicyResult{}
 	seen := make(map[policyKey]struct{}, len(result.Data))
 

--- a/internal/scanners/defender.go
+++ b/internal/scanners/defender.go
@@ -36,7 +36,11 @@ func (s *DefenderScanner) Scan(ctx context.Context, cred azcore.TokenCredential,
 	for s := range subscriptions {
 		subs = append(subs, to.Ptr(s))
 	}
-	result := graphClient.Query(ctx, query, subs)
+	result, err := graphClient.Query(ctx, query, subs)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to query Azure Resource Graph for Defender status")
+		return nil
+	}
 	resources := []*models.DefenderResult{}
 	if result.Data != nil {
 		for _, row := range result.Data {
@@ -105,7 +109,11 @@ func (s *DefenderScanner) GetRecommendations(ctx context.Context, cred azcore.To
 		recommendationName string
 	}
 
-	result := graphClient.Query(ctx, query, subs)
+	result, err := graphClient.Query(ctx, query, subs)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to query Azure Resource Graph for Defender recommendations")
+		return nil
+	}
 	resources := []*models.DefenderRecommendation{}
 	seen := make(map[defenderKey]struct{}, len(result.Data))
 	if result.Data != nil {

--- a/internal/scanners/plugins/openai/throttling.go
+++ b/internal/scanners/plugins/openai/throttling.go
@@ -212,7 +212,10 @@ func (s *ThrottlingScanner) discoverOpenAIResources(ctx context.Context, cred az
 		subs = append(subs, to.Ptr(s))
 	}
 
-	result := graphClient.Query(ctx, query, subs)
+	result, err := graphClient.Query(ctx, query, subs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query openai resources from resource graph: %w", err)
+	}
 
 	resources := make([]*models.Resource, 0, len(result.Data))
 	for _, row := range result.Data {

--- a/internal/scanners/resources.go
+++ b/internal/scanners/resources.go
@@ -23,7 +23,11 @@ func (sc *ResourceDiscovery) GetAllResources(ctx context.Context, cred azcore.To
 	for s := range subscriptions {
 		subs = append(subs, to.Ptr(s))
 	}
-	result := graphClient.Query(ctx, query, subs)
+	result, err := graphClient.Query(ctx, query, subs)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to query Azure Resource Graph for resources")
+		return nil, nil
+	}
 	resources := []*models.Resource{}
 	excludedResources := []*models.Resource{}
 	if result.Data != nil {
@@ -99,7 +103,11 @@ func (sc ResourceDiscovery) GetCountPerResourceTypeAndSubscription(ctx context.C
 	for s := range subscriptions {
 		subs = append(subs, to.Ptr(s))
 	}
-	result := graphClient.Query(ctx, query, subs)
+	result, err := graphClient.Query(ctx, query, subs)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to query Azure Resource Graph for resource counts by subscription and type")
+		return nil
+	}
 	resources := []*models.ResourceTypeCount{}
 	if result.Data != nil {
 		for _, row := range result.Data {
@@ -129,7 +137,11 @@ func (sc ResourceDiscovery) GetCountPerResourceType(ctx context.Context, cred az
 	for s := range subscriptions {
 		subs = append(subs, to.Ptr(s))
 	}
-	result := graphClient.Query(ctx, query, subs)
+	result, err := graphClient.Query(ctx, query, subs)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to query Azure Resource Graph for resource counts by type")
+		return map[string]float64{}
+	}
 	resources := map[string]float64{}
 	if result.Data != nil {
 		for _, row := range result.Data {


### PR DESCRIPTION
# Description

This pull request improves error handling and resilience when querying the Azure Resource Graph across multiple scanners and utilities. The main change is that `GraphQueryClient.Query` now returns an error, allowing callers to handle failures gracefully instead of terminating the process. Additionally, a new utility function enables selective skipping of unsupported logical table errors, which avoids unnecessary failures for known, ignorable cases.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #847 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
