### PR TITLE
Add sql-esu internal plugin for SQL Server EOL/ESU status

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,25 @@ azqr region-selection --target-regions=swedencentral,germanywestcentral,italynor
 azqr scan --plugin region-selection
 ```
 
+### SQL Server ESU Status
+
+Analyzes SQL Server End-of-Life (EOL) and Extended Security Update (ESU) status across Arc-enabled SQL Server instances and SQL Virtual Machines.
+
+- Detects EOL status dynamically (Expired, ESU Active, Upcoming ESU, Supported)
+- Calculates ESU licensing costs per instance (by edition and core count)
+- Estimates SQL Managed Instance migration savings
+- Covers Arc-enabled SQL (on-prem) and Azure VM (SQL IaaS)
+
+**Use Cases**: ESU cost forecasting, migration planning to SQL MI, compliance reporting, license optimization
+
+```bash
+# Run as standalone command (fast, plugin-only mode)
+azqr sql-esu
+
+# Or integrate with full scan
+azqr scan --plugin sql-esu
+```
+
 [Internal Plugins Documentation](https://azure.github.io/azqr/docs/plugins/internal-plugins/)
 
 ### Combining Features
@@ -426,6 +445,7 @@ azqr scan --subscription-id <sub-id> \
   --plugin carbon-emissions \
   --plugin zone-mapping \
   --plugin region-selection \
+  --plugin sql-esu \
   --output-name comprehensive-analysis
 ```
 

--- a/cmd/azqr/main.go
+++ b/cmd/azqr/main.go
@@ -9,6 +9,7 @@ import (
 	// Import internal plugins to register them
 	_ "github.com/Azure/azqr/internal/scanners/plugins/carbon"
 	_ "github.com/Azure/azqr/internal/scanners/plugins/openai"
+	_ "github.com/Azure/azqr/internal/scanners/plugins/sqlesu"
 	_ "github.com/Azure/azqr/internal/scanners/plugins/zone"
 	_ "github.com/Azure/azqr/internal/scanners/plugins/region"
 )

--- a/docs/content/en/docs/Plugins/internal-plugins.md
+++ b/docs/content/en/docs/Plugins/internal-plugins.md
@@ -148,6 +148,38 @@ Availability zone loss/gain applies a multiplicative adjustment to the final sco
 - Recommendation Score, Score Quality, Recommendation
 - Missing Resource Types, Unavailable SKUs (detail), Restricted SKUs (detail)
 
+### 5. SQL Server ESU Status
+
+**Plugin Name**: `sql-esu`  
+**Command**: `azqr sql-esu`  
+**Flag**: `--plugin sql-esu`  
+**Version**: 0.1.0-beta
+
+Analyzes SQL Server End-of-Life (EOL) and Extended Security Update (ESU) status across Arc-enabled SQL Server instances and SQL Virtual Machines on Azure.
+
+**Key Features**:
+- Detects EOL status dynamically using current date (Expired, ESU Active, Upcoming ESU, Supported)
+- Calculates ESU licensing costs per instance based on edition and vCore count
+- Estimates SQL Managed Instance migration savings
+- Covers both Arc-enabled SQL (on-prem) and Azure VM (SQL IaaS)
+
+**Use Cases**:
+- ESU cost forecasting and budgeting
+- Migration planning to Azure SQL Managed Instance
+- Compliance reporting for end-of-support software
+- License optimization across SQL estates
+
+**Output Columns**:
+- Name, Resource Group, Subscription, Location
+- Cloud Type (Arc-enabled or Azure VM)
+- SQL Version, Edition, vCores
+- EOL Status (Expired / ESU Active / Upcoming ESU / Supported)
+- Mainstream End Date, ESU End Date
+- ESU Monthly Cost/Core, Billable Cores
+- Estimated Monthly/Annual/3-Year Cost
+- Patch Ops Monthly Cost
+- Est SQL MI Monthly Cost, Est SQL MI Monthly Saving
+
 ---
 
 ## Usage
@@ -176,6 +208,9 @@ azqr region-selection
 # Narrow region selection to specific target regions
 azqr region-selection --target-regions=swedencentral,germanywestcentral
 
+# Run SQL ESU plugin
+azqr sql-esu
+
 # Run with specific subscriptions
 azqr zone-mapping --subscription-id <sub-id>
 
@@ -197,7 +232,7 @@ Run plugins alongside standard compliance scanning using the `--plugin` flag:
 azqr scan --plugin openai-throttling
 
 # Enable multiple plugins during scan
-azqr scan --plugin openai-throttling --plugin carbon-emissions --plugin zone-mapping --plugin region-selection
+azqr scan --plugin openai-throttling --plugin carbon-emissions --plugin zone-mapping --plugin region-selection --plugin sql-esu
 
 # Combine with other scan options
 azqr scan --subscription-id <sub-id> --plugin zone-mapping --output-name analysis
@@ -222,7 +257,8 @@ NAME                  VERSION    TYPE       DESCRIPTION
 openai-throttling     1.0.0      internal   Checks OpenAI/Cognitive Services accounts for...
 carbon-emissions      1.0.0      internal   Analyzes carbon emissions by Azure resource type
 zone-mapping          1.0.0      internal   Retrieves logical-to-physical availability zone mappings...
-region-selection      0.1.0      internal   Scores and ranks Azure regions for workload migration...
+region-selection      0.1.0-beta internal   Scores and ranks Azure regions for workload migration...
+sql-esu               0.1.0-beta internal   Analyzes SQL Server End-of-Life and Extended Security Update status
 ```
 
 ### Plugin Details
@@ -244,8 +280,9 @@ Each internal plugin creates a dedicated worksheet in the Excel workbook:
 - **OpenAI Throttling** sheet  
 - **Carbon Emissions** sheet
 - **Region Selection** sheet (main scored table)
-- **Svc Avail `<region>`** sheets — one per target region with per-resource-type availability
-- **CostComparison** sheet — per-meter retail pricing across all analysed regions
+  - **Svc Avail `<region>`** sheets — one per target region with per-resource-type availability
+  - **CostComparison** sheet — per-meter retail pricing across all analysed regions
+- **SQL ESU** sheet
 
 ```bash
 # Run plugins as standalone commands (fastest)
@@ -339,6 +376,7 @@ Internal plugins may require additional permissions beyond standard `Reader` acc
 | **zone-mapping** | Reader | Subscriptions API (locations endpoint) |
 | **openai-throttling** | Reader + Monitoring Reader | Cognitive Services, Monitor Metrics |
 | **carbon-emissions** | Reader | Carbon Optimization API |
+| **sql-esu** | Reader | Azure Resource Graph |
 
 **Recommended**: Assign `Reader` and `Monitoring Reader` roles at subscription or management group scope.
 
@@ -349,6 +387,7 @@ Internal plugins add processing time to scans:
 - **openai-throttling**: 1-3 minutes (depends on number of OpenAI accounts)
 - **carbon-emissions**: 1-2 minutes (depends on subscription count)
 - **zone-mapping**: <10 seconds (very fast, one API call per subscription)
+- **sql-esu**: <30 seconds (single Azure Resource Graph query)
 
 **Optimization Tips**:
 - Enable only needed plugins

--- a/docs/content/en/docs/Plugins/internal-plugins.md
+++ b/docs/content/en/docs/Plugins/internal-plugins.md
@@ -174,11 +174,12 @@ Analyzes SQL Server End-of-Life (EOL) and Extended Security Update (ESU) status 
 - Cloud Type (Arc-enabled or Azure VM)
 - SQL Version, Edition, vCores
 - EOL Status (Expired / ESU Active / Upcoming ESU / Supported)
-- Mainstream End Date, ESU End Date
+- Mainstream End Date, ESU Start Date, ESU End Date
 - ESU Monthly Cost/Core, Billable Cores
 - Estimated Monthly/Annual/3-Year Cost
-- Patch Ops Monthly Cost
-- Est SQL MI Monthly Cost, Est SQL MI Monthly Saving
+- Patch Ops Monthly/Annual/3-Year Cost
+- Est SQL MI Monthly/Annual/3-Year Cost
+- Est SQL MI Monthly/Annual/3-Year Saving
 
 ---
 

--- a/docs/content/en/docs/Usage/_index.md
+++ b/docs/content/en/docs/Usage/_index.md
@@ -265,6 +265,9 @@ azqr carbon-emissions
 # Run zone mapping analysis
 azqr zone-mapping
 
+# Run SQL ESU analysis
+azqr sql-esu
+
 # With specific subscription
 azqr zone-mapping --subscription-id <sub-id>
 ```
@@ -278,7 +281,7 @@ Run plugins alongside standard scanning:
 azqr scan --plugin openai-throttling
 
 # Multiple plugins with scan
-azqr scan --plugin openai-throttling --plugin carbon-emissions --plugin zone-mapping
+azqr scan --plugin openai-throttling --plugin carbon-emissions --plugin zone-mapping --plugin sql-esu
 
 # With other options
 azqr scan --subscription-id <sub-id> --plugin zone-mapping

--- a/internal/scanners/plugins/sqlesu/kql/sql-esu.kql
+++ b/internal/scanners/plugins/sqlesu/kql/sql-esu.kql
@@ -1,0 +1,149 @@
+// SQL Server EOL / ESU Status — Azure Resource Graph query
+// Covers: Arc-enabled SQL (microsoft.azurearcdata/sqlserverinstances)
+//         SQL VMs on Azure (microsoft.sqlvirtualmachine/sqlvirtualmachines)
+resources
+| where type == "microsoft.azurearcdata/sqlserverinstances"
+    or type == "microsoft.sqlvirtualmachine/sqlvirtualmachines"
+| extend SQLVersion = iff(
+    type == "microsoft.azurearcdata/sqlserverinstances",
+    tostring(properties.version),
+    strcat("SQL Server ", substring(tostring(properties.sqlImageOffer), 3, 4))
+)
+| extend Edition = iff(
+    type == "microsoft.azurearcdata/sqlserverinstances",
+    tostring(properties.edition),
+    tostring(properties.sqlImageSku)
+)
+| extend CloudType = iff(
+    type == "microsoft.azurearcdata/sqlserverinstances",
+    "Arc-enabled (On-Prem)",
+    "Azure VM (SQL IaaS)"
+)
+| extend _vmId = iff(type == "microsoft.sqlvirtualmachine/sqlvirtualmachines", tolower(tostring(properties.virtualMachineResourceId)), "")
+| join kind=leftouter (
+    resources
+    | where type == "microsoft.compute/virtualmachines"
+    | project _vmId = tolower(id), _vmSize = tostring(properties.hardwareProfile.vmSize)
+) on _vmId
+| extend vCores = case(
+    type == "microsoft.azurearcdata/sqlserverinstances", coalesce(toint(properties.vCore), 0),
+    tolower(_vmSize) == "standard_d1_v2",      1,  tolower(_vmSize) == "standard_d2_v2",      2,
+    tolower(_vmSize) == "standard_d3_v2",      4,  tolower(_vmSize) == "standard_d4_v2",      8,
+    tolower(_vmSize) == "standard_d5_v2",      16, tolower(_vmSize) == "standard_d11_v2",     2,
+    tolower(_vmSize) == "standard_d12_v2",     4,  tolower(_vmSize) == "standard_d13_v2",     8,
+    tolower(_vmSize) == "standard_d14_v2",     16,
+    tolower(_vmSize) == "standard_ds1_v2",     1,  tolower(_vmSize) == "standard_ds2_v2",     2,
+    tolower(_vmSize) == "standard_ds3_v2",     4,  tolower(_vmSize) == "standard_ds4_v2",     8,
+    tolower(_vmSize) == "standard_ds5_v2",     16, tolower(_vmSize) == "standard_ds11_v2",    2,
+    tolower(_vmSize) == "standard_ds11-1_v2",  1,
+    tolower(_vmSize) == "standard_ds12_v2",    4,  tolower(_vmSize) == "standard_ds12-1_v2",  1,
+    tolower(_vmSize) == "standard_ds12-2_v2",  2,
+    tolower(_vmSize) == "standard_ds13_v2",    8,  tolower(_vmSize) == "standard_ds13-2_v2",  2,
+    tolower(_vmSize) == "standard_ds13-4_v2",  4,
+    tolower(_vmSize) == "standard_ds14_v2",    16, tolower(_vmSize) == "standard_ds14-4_v2",  4,
+    tolower(_vmSize) == "standard_ds14-8_v2",  8,  tolower(_vmSize) == "standard_ds15_v2",    20,
+    tolower(_vmSize) == "standard_g1",         2,  tolower(_vmSize) == "standard_g2",         4,
+    tolower(_vmSize) == "standard_g3",         8,  tolower(_vmSize) == "standard_g4",         16,
+    tolower(_vmSize) == "standard_g5",         32,
+    tolower(_vmSize) == "standard_gs1",        2,  tolower(_vmSize) == "standard_gs2",        4,
+    tolower(_vmSize) == "standard_gs3",        8,  tolower(_vmSize) == "standard_gs4",        16,
+    tolower(_vmSize) == "standard_gs4-4",      4,  tolower(_vmSize) == "standard_gs4-8",      8,
+    tolower(_vmSize) == "standard_gs5",        32, tolower(_vmSize) == "standard_gs5-8",      8,
+    tolower(_vmSize) == "standard_gs5-16",     16,
+    tolower(_vmSize) == "standard_m8ms",       8,  tolower(_vmSize) == "standard_m16ms",      16,
+    tolower(_vmSize) == "standard_m32ts",      32, tolower(_vmSize) == "standard_m32ls",      32,
+    tolower(_vmSize) == "standard_m32ms",      32, tolower(_vmSize) == "standard_m64",        64,
+    tolower(_vmSize) == "standard_m64ms",      64, tolower(_vmSize) == "standard_m64ls",      64,
+    tolower(_vmSize) == "standard_m64s",       64, tolower(_vmSize) == "standard_m128ms",     128,
+    tolower(_vmSize) == "standard_m128s",      128,
+    tolower(_vmSize) == "standard_m8-2ms",     2,  tolower(_vmSize) == "standard_m8-4ms",     4,
+    tolower(_vmSize) == "standard_m16-4ms",    4,  tolower(_vmSize) == "standard_m16-8ms",    8,
+    tolower(_vmSize) == "standard_m32-8ms",    8,  tolower(_vmSize) == "standard_m32-16ms",   16,
+    tolower(_vmSize) == "standard_m64-16ms",   16, tolower(_vmSize) == "standard_m64-32ms",   32,
+    tolower(_vmSize) == "standard_m128-32ms",  32, tolower(_vmSize) == "standard_m128-64ms",  64,
+    coalesce(toint(extract(@'_[A-Za-z]+(\d+)', 1, _vmSize)), 4)
+)
+| extend _now = now()
+| extend EOLStatus = case(
+    SQLVersion == "SQL Server 2008",                                        "Expired",
+    SQLVersion == "SQL Server 2008 R2",                                     "Expired",
+    SQLVersion == "SQL Server 2012",                                        "Expired",
+    SQLVersion == "SQL Server 2014" and _now >= datetime(2027-07-12),       "Expired",
+    SQLVersion == "SQL Server 2014",                                        "ESU Active",
+    SQLVersion == "SQL Server 2016" and _now >= datetime(2029-07-14),       "Expired",
+    SQLVersion == "SQL Server 2016" and _now >= datetime(2026-07-14),       "ESU Active",
+    SQLVersion == "SQL Server 2016",                                        "Upcoming ESU",
+    SQLVersion == "SQL Server 2017" and _now >= datetime(2030-10-12),       "Expired",
+    SQLVersion == "SQL Server 2017" and _now >= datetime(2027-10-12),       "ESU Active",
+    SQLVersion == "SQL Server 2017",                                        "Supported",
+    SQLVersion == "SQL Server 2019",                                        "Supported",
+    SQLVersion == "SQL Server 2022",                                        "Supported",
+    "Unknown"
+)
+| extend MainstreamEndDate = case(
+    SQLVersion == "SQL Server 2008",    datetime(2012-04-12),
+    SQLVersion == "SQL Server 2008 R2", datetime(2014-07-08),
+    SQLVersion == "SQL Server 2012",    datetime(2017-07-11),
+    SQLVersion == "SQL Server 2014",    datetime(2019-07-09),
+    SQLVersion == "SQL Server 2016",    datetime(2021-07-13),
+    SQLVersion == "SQL Server 2017",    datetime(2022-10-11),
+    SQLVersion == "SQL Server 2019",    datetime(2025-01-08),
+    SQLVersion == "SQL Server 2022",    datetime(2028-01-11),
+    datetime(2099-01-01)
+)
+| extend ESUEndDate = case(
+    SQLVersion == "SQL Server 2008",    datetime(2019-07-09),
+    SQLVersion == "SQL Server 2008 R2", datetime(2019-07-09),
+    SQLVersion == "SQL Server 2012",    datetime(2025-07-08),
+    SQLVersion == "SQL Server 2014",    datetime(2027-07-12),
+    SQLVersion == "SQL Server 2016",    datetime(2029-07-14),
+    SQLVersion == "SQL Server 2017",    datetime(2030-10-12),
+    SQLVersion == "SQL Server 2019",    datetime(2033-01-08),
+    SQLVersion == "SQL Server 2022",    datetime(2036-01-11),
+    datetime(2099-01-01)
+)
+| extend ESUMonthlyCostPerCore = case(
+    (SQLVersion == "SQL Server 2014" or SQLVersion == "SQL Server 2016" or SQLVersion == "SQL Server 2017")
+        and tolower(Edition) contains "enterprise", 540.5,
+    (SQLVersion == "SQL Server 2014" or SQLVersion == "SQL Server 2016" or SQLVersion == "SQL Server 2017")
+        and tolower(Edition) contains "developer",  0.0,
+    SQLVersion == "SQL Server 2014", 139.0,
+    SQLVersion == "SQL Server 2016", 139.0,
+    SQLVersion == "SQL Server 2017", 139.0,
+    0.0
+)
+| extend BillableCores        = iff(vCores < 4, 4, vCores)
+| extend EstimatedMonthlyCost = ESUMonthlyCostPerCore * BillableCores
+| extend _miVCores = iff(vCores < 4, 4, vCores)
+| extend EstSQLMIMonthlyCost = case(
+    tolower(Edition) contains "enterprise", 367.0 * _miVCores,
+    tolower(Edition) contains "developer",   0.0,
+    123.0 * _miVCores
+)
+| extend PatchOpsMonthlyCost = 160.0
+| extend EstSQLMISaving = iff(
+    EstimatedMonthlyCost == 0.0,
+    PatchOpsMonthlyCost,
+    EstimatedMonthlyCost + PatchOpsMonthlyCost - EstSQLMIMonthlyCost
+)
+| project
+    Name = name,
+    ResourceGroup = resourceGroup,
+    SubscriptionId = subscriptionId,
+    Location = location,
+    CloudType,
+    SQLVersion,
+    Edition,
+    vCores,
+    EOLStatus,
+    MainstreamEndDate,
+    ESUEndDate,
+    ESUMonthlyCostPerCore,
+    BillableCores,
+    EstimatedMonthlyCost,
+    EstimatedAnnualCost = EstimatedMonthlyCost * 12,
+    EstimatedThreeYearCost = EstimatedMonthlyCost * 36,
+    PatchOpsMonthlyCost,
+    EstSQLMIMonthlyCost,
+    EstSQLMISaving
+| order by EOLStatus asc, SQLVersion asc, Name asc

--- a/internal/scanners/plugins/sqlesu/kql/sql-esu.kql
+++ b/internal/scanners/plugins/sqlesu/kql/sql-esu.kql
@@ -7,7 +7,7 @@ resources
 | extend SQLVersion = iff(
     type == "microsoft.azurearcdata/sqlserverinstances",
     tostring(properties.version),
-    strcat("SQL Server ", substring(tostring(properties.sqlImageOffer), 3, 4))
+    strcat("SQL Server ", replace_string(extract(@'(?i)sql(\d{4}(?:R2)?)', 1, tostring(properties.sqlImageOffer)), "2008R2", "2008 R2"))
 )
 | extend Edition = iff(
     type == "microsoft.azurearcdata/sqlserverinstances",
@@ -19,14 +19,18 @@ resources
     "Arc-enabled (On-Prem)",
     "Azure VM (SQL IaaS)"
 )
+// For SQL VMs, core count lives on the underlying compute VM — join to retrieve it
 | extend _vmId = iff(type == "microsoft.sqlvirtualmachine/sqlvirtualmachines", tolower(tostring(properties.virtualMachineResourceId)), "")
 | join kind=leftouter (
     resources
     | where type == "microsoft.compute/virtualmachines"
     | project _vmId = tolower(id), _vmSize = tostring(properties.hardwareProfile.vmSize)
 ) on _vmId
+// Arc SQL: properties.vCore  |  SQL MI: sku.capacity  |  SQL VM: case() lookup on VM size SKU
 | extend vCores = case(
+    // Arc SQL instances have direct properties
     type == "microsoft.azurearcdata/sqlserverinstances", coalesce(toint(properties.vCore), 0),
+    // SQL VMs: exact lookup for legacy series (SKU number ≠ vCPU), regex fallback for modern v3/v4/v5/v6
     tolower(_vmSize) == "standard_d1_v2",      1,  tolower(_vmSize) == "standard_d2_v2",      2,
     tolower(_vmSize) == "standard_d3_v2",      4,  tolower(_vmSize) == "standard_d4_v2",      8,
     tolower(_vmSize) == "standard_d5_v2",      16, tolower(_vmSize) == "standard_d11_v2",     2,
@@ -61,8 +65,10 @@ resources
     tolower(_vmSize) == "standard_m32-8ms",    8,  tolower(_vmSize) == "standard_m32-16ms",   16,
     tolower(_vmSize) == "standard_m64-16ms",   16, tolower(_vmSize) == "standard_m64-32ms",   32,
     tolower(_vmSize) == "standard_m128-32ms",  32, tolower(_vmSize) == "standard_m128-64ms",  64,
-    coalesce(toint(extract(@'_[A-Za-z]+(\d+)', 1, _vmSize)), 4)
+    // Modern SKUs: try constrained-vCore pattern first (e.g. E16-8ds_v5 → 8), then standard (e.g. D8s_v5 → 8)
+    coalesce(toint(extract(@'_[A-Za-z]+\d+-(\d+)', 1, _vmSize)), toint(extract(@'_[A-Za-z]+(\d+)', 1, _vmSize)), 4)
 )
+// Use now() so status flips automatically on ESU start/end dates
 | extend _now = now()
 | extend EOLStatus = case(
     SQLVersion == "SQL Server 2008",                                        "Expired",
@@ -76,51 +82,70 @@ resources
     SQLVersion == "SQL Server 2017" and _now >= datetime(2030-10-12),       "Expired",
     SQLVersion == "SQL Server 2017" and _now >= datetime(2027-10-12),       "ESU Active",
     SQLVersion == "SQL Server 2017",                                        "Supported",
+    SQLVersion == "SQL Server 2019" and _now >= datetime(2033-01-08),       "Expired",
+    SQLVersion == "SQL Server 2019" and _now >= datetime(2030-01-08),       "ESU Active",
+    SQLVersion == "SQL Server 2019" and _now >= datetime(2029-07-01),       "Upcoming ESU", // 6 months before ESU start date to allow for planning
     SQLVersion == "SQL Server 2019",                                        "Supported",
+    SQLVersion == "SQL Server 2022" and _now >= datetime(2036-01-11),       "Expired",
+    SQLVersion == "SQL Server 2022" and _now >= datetime(2033-01-11),       "ESU Active",
+    SQLVersion == "SQL Server 2022" and _now >= datetime(2032-07-01),       "Upcoming ESU", // 6 months before ESU start date to allow for planning
     SQLVersion == "SQL Server 2022",                                        "Supported",
     "Unknown"
 )
 | extend MainstreamEndDate = case(
-    SQLVersion == "SQL Server 2008",    datetime(2012-04-12),
-    SQLVersion == "SQL Server 2008 R2", datetime(2014-07-08),
     SQLVersion == "SQL Server 2012",    datetime(2017-07-11),
     SQLVersion == "SQL Server 2014",    datetime(2019-07-09),
     SQLVersion == "SQL Server 2016",    datetime(2021-07-13),
     SQLVersion == "SQL Server 2017",    datetime(2022-10-11),
-    SQLVersion == "SQL Server 2019",    datetime(2025-01-08),
+    SQLVersion == "SQL Server 2019",    datetime(2025-02-28),
     SQLVersion == "SQL Server 2022",    datetime(2028-01-11),
-    datetime(2099-01-01)
+    todatetime('')
 )
 | extend ESUEndDate = case(
-    SQLVersion == "SQL Server 2008",    datetime(2019-07-09),
-    SQLVersion == "SQL Server 2008 R2", datetime(2019-07-09),
     SQLVersion == "SQL Server 2012",    datetime(2025-07-08),
     SQLVersion == "SQL Server 2014",    datetime(2027-07-12),
     SQLVersion == "SQL Server 2016",    datetime(2029-07-14),
     SQLVersion == "SQL Server 2017",    datetime(2030-10-12),
     SQLVersion == "SQL Server 2019",    datetime(2033-01-08),
     SQLVersion == "SQL Server 2022",    datetime(2036-01-11),
-    datetime(2099-01-01)
+    todatetime('')
 )
+// ESUStartDate = date the ESU program begins
+| extend ESUStartDate = case(
+    SQLVersion == "SQL Server 2012",    datetime(2022-07-12),
+    SQLVersion == "SQL Server 2014",    datetime(2024-07-09),
+    SQLVersion == "SQL Server 2016",    datetime(2026-07-14),
+    SQLVersion == "SQL Server 2017",    datetime(2027-10-12),
+    SQLVersion == "SQL Server 2019",    datetime(2030-01-08),
+    SQLVersion == "SQL Server 2022",    datetime(2033-01-11),
+    todatetime('')
+)
+// ESU pricing varies by edition: Enterprise is ~4x Standard; Developer/Express free
+// Standard/Web: $139/core/mo  |  Enterprise: $540.50/core/mo  |  Developer/Express: $0
+| extend _esuVersions = SQLVersion == "SQL Server 2014" or SQLVersion == "SQL Server 2016" or SQLVersion == "SQL Server 2017" or SQLVersion == "SQL Server 2019" or SQLVersion == "SQL Server 2022"
 | extend ESUMonthlyCostPerCore = case(
-    (SQLVersion == "SQL Server 2014" or SQLVersion == "SQL Server 2016" or SQLVersion == "SQL Server 2017")
-        and tolower(Edition) contains "enterprise", 540.5,
-    (SQLVersion == "SQL Server 2014" or SQLVersion == "SQL Server 2016" or SQLVersion == "SQL Server 2017")
-        and tolower(Edition) contains "developer",  0.0,
+    _esuVersions and tolower(Edition) contains "enterprise", 540.5,
+    _esuVersions and tolower(Edition) contains "developer",  0.0,
+    _esuVersions and tolower(Edition) contains "express",    0.0,
     SQLVersion == "SQL Server 2014", 139.0,
     SQLVersion == "SQL Server 2016", 139.0,
     SQLVersion == "SQL Server 2017", 139.0,
+    SQLVersion == "SQL Server 2019", 139.0,
+    SQLVersion == "SQL Server 2022", 139.0,
     0.0
 )
 | extend BillableCores        = iff(vCores < 4, 4, vCores)
-| extend EstimatedMonthlyCost = ESUMonthlyCostPerCore * BillableCores
-| extend _miVCores = iff(vCores < 4, 4, vCores)
+// EstimatedMonthlyCost is non-zero for ESU Active (currently paying) and Upcoming ESU (forecast)
+| extend EstimatedMonthlyCost = iff(EOLStatus in ("ESU Active", "Upcoming ESU"), ESUMonthlyCostPerCore * BillableCores, 0.0)
+// Est. cost if migrated to Azure SQL MI (GP ~$123/vCore, BC ~$367/vCore, min 4 vCores)
 | extend EstSQLMIMonthlyCost = case(
-    tolower(Edition) contains "enterprise", 367.0 * _miVCores,
-    tolower(Edition) contains "developer",   0.0,
-    123.0 * _miVCores
+    tolower(Edition) contains "enterprise", 367.0 * BillableCores,
+    123.0 * BillableCores  // Standard, Web, Express, Developer all → GP tier
 )
+// Patch operations cost: 2h/month × $80/h = $160/month per instance
 | extend PatchOpsMonthlyCost = 160.0
+// Expired/Supported have no ESU cost — saving reflects patch ops avoided by migrating to MI ($160/mo)
+// ESU Active/Upcoming — saving = ESU cost + patch ops − MI cost
 | extend EstSQLMISaving = iff(
     EstimatedMonthlyCost == 0.0,
     PatchOpsMonthlyCost,
@@ -137,6 +162,7 @@ resources
     vCores,
     EOLStatus,
     MainstreamEndDate,
+    ESUStartDate,
     ESUEndDate,
     ESUMonthlyCostPerCore,
     BillableCores,
@@ -144,6 +170,12 @@ resources
     EstimatedAnnualCost = EstimatedMonthlyCost * 12,
     EstimatedThreeYearCost = EstimatedMonthlyCost * 36,
     PatchOpsMonthlyCost,
+    PatchOpsAnnualCost = PatchOpsMonthlyCost * 12,
+    PatchOpsThreeYearCost = PatchOpsMonthlyCost * 36,
     EstSQLMIMonthlyCost,
-    EstSQLMISaving
-| order by EOLStatus asc, SQLVersion asc, Name asc
+    EstSQLMIAnnualCost = EstSQLMIMonthlyCost * 12,
+    EstSQLMIThreeYearCost = EstSQLMIMonthlyCost * 36,
+    EstSQLMISaving,
+    EstSQLMIAnnualSaving = EstSQLMISaving * 12,
+    EstSQLMIThreeYearSaving = EstSQLMISaving * 36
+| order by case(EOLStatus == "Expired", 0, EOLStatus == "ESU Active", 1, EOLStatus == "Upcoming ESU", 2, EOLStatus == "Supported", 3, 4) asc, SQLVersion asc, Name asc

--- a/internal/scanners/plugins/sqlesu/sqlesu.go
+++ b/internal/scanners/plugins/sqlesu/sqlesu.go
@@ -103,13 +103,8 @@ func (s *Scanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscri
 				continue
 			}
 
-			name := to.String(m["Name"])
-			if filters.Azqr.IsServiceExcluded(name) {
-				continue
-			}
-
 			table = append(table, []string{
-				name,
+				to.String(m["Name"]),
 				to.String(m["ResourceGroup"]),
 				subscription,
 				to.String(m["Location"]),

--- a/internal/scanners/plugins/sqlesu/sqlesu.go
+++ b/internal/scanners/plugins/sqlesu/sqlesu.go
@@ -5,6 +5,7 @@ package sqlesu
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 
 	"github.com/Azure/azqr/internal/graph"
@@ -14,6 +15,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/rs/zerolog/log"
 )
+
+//go:embed kql/sql-esu.kql
+var sqlESUQuery string
 
 // Scanner is an internal plugin that scans SQL Server EOL/ESU status
 type Scanner struct{}
@@ -62,155 +66,6 @@ func (s *Scanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscri
 
 	graphClient := graph.NewGraphQuery(cred)
 
-	query := `
-resources
-| where type == "microsoft.azurearcdata/sqlserverinstances"
-    or type == "microsoft.sqlvirtualmachine/sqlvirtualmachines"
-| extend SQLVersion = iff(
-    type == "microsoft.azurearcdata/sqlserverinstances",
-    tostring(properties.version),
-    strcat("SQL Server ", substring(tostring(properties.sqlImageOffer), 3, 4))
-)
-| extend Edition = iff(
-    type == "microsoft.azurearcdata/sqlserverinstances",
-    tostring(properties.edition),
-    tostring(properties.sqlImageSku)
-)
-| extend CloudType = iff(
-    type == "microsoft.azurearcdata/sqlserverinstances",
-    "Arc-enabled (On-Prem)",
-    "Azure VM (SQL IaaS)"
-)
-| extend _vmId = iff(type == "microsoft.sqlvirtualmachine/sqlvirtualmachines", tolower(tostring(properties.virtualMachineResourceId)), "")
-| join kind=leftouter (
-    resources
-    | where type == "microsoft.compute/virtualmachines"
-    | project _vmId = tolower(id), _vmSize = tostring(properties.hardwareProfile.vmSize)
-) on _vmId
-| extend vCores = case(
-    type == "microsoft.azurearcdata/sqlserverinstances", coalesce(toint(properties.vCore), 0),
-    tolower(_vmSize) == "standard_d1_v2",      1,  tolower(_vmSize) == "standard_d2_v2",      2,
-    tolower(_vmSize) == "standard_d3_v2",      4,  tolower(_vmSize) == "standard_d4_v2",      8,
-    tolower(_vmSize) == "standard_d5_v2",      16, tolower(_vmSize) == "standard_d11_v2",     2,
-    tolower(_vmSize) == "standard_d12_v2",     4,  tolower(_vmSize) == "standard_d13_v2",     8,
-    tolower(_vmSize) == "standard_d14_v2",     16,
-    tolower(_vmSize) == "standard_ds1_v2",     1,  tolower(_vmSize) == "standard_ds2_v2",     2,
-    tolower(_vmSize) == "standard_ds3_v2",     4,  tolower(_vmSize) == "standard_ds4_v2",     8,
-    tolower(_vmSize) == "standard_ds5_v2",     16, tolower(_vmSize) == "standard_ds11_v2",    2,
-    tolower(_vmSize) == "standard_ds11-1_v2",  1,
-    tolower(_vmSize) == "standard_ds12_v2",    4,  tolower(_vmSize) == "standard_ds12-1_v2",  1,
-    tolower(_vmSize) == "standard_ds12-2_v2",  2,
-    tolower(_vmSize) == "standard_ds13_v2",    8,  tolower(_vmSize) == "standard_ds13-2_v2",  2,
-    tolower(_vmSize) == "standard_ds13-4_v2",  4,
-    tolower(_vmSize) == "standard_ds14_v2",    16, tolower(_vmSize) == "standard_ds14-4_v2",  4,
-    tolower(_vmSize) == "standard_ds14-8_v2",  8,  tolower(_vmSize) == "standard_ds15_v2",    20,
-    tolower(_vmSize) == "standard_g1",         2,  tolower(_vmSize) == "standard_g2",         4,
-    tolower(_vmSize) == "standard_g3",         8,  tolower(_vmSize) == "standard_g4",         16,
-    tolower(_vmSize) == "standard_g5",         32,
-    tolower(_vmSize) == "standard_gs1",        2,  tolower(_vmSize) == "standard_gs2",        4,
-    tolower(_vmSize) == "standard_gs3",        8,  tolower(_vmSize) == "standard_gs4",        16,
-    tolower(_vmSize) == "standard_gs4-4",      4,  tolower(_vmSize) == "standard_gs4-8",      8,
-    tolower(_vmSize) == "standard_gs5",        32, tolower(_vmSize) == "standard_gs5-8",      8,
-    tolower(_vmSize) == "standard_gs5-16",     16,
-    tolower(_vmSize) == "standard_m8ms",       8,  tolower(_vmSize) == "standard_m16ms",      16,
-    tolower(_vmSize) == "standard_m32ts",      32, tolower(_vmSize) == "standard_m32ls",      32,
-    tolower(_vmSize) == "standard_m32ms",      32, tolower(_vmSize) == "standard_m64",        64,
-    tolower(_vmSize) == "standard_m64ms",      64, tolower(_vmSize) == "standard_m64ls",      64,
-    tolower(_vmSize) == "standard_m64s",       64, tolower(_vmSize) == "standard_m128ms",     128,
-    tolower(_vmSize) == "standard_m128s",      128,
-    tolower(_vmSize) == "standard_m8-2ms",     2,  tolower(_vmSize) == "standard_m8-4ms",     4,
-    tolower(_vmSize) == "standard_m16-4ms",    4,  tolower(_vmSize) == "standard_m16-8ms",    8,
-    tolower(_vmSize) == "standard_m32-8ms",    8,  tolower(_vmSize) == "standard_m32-16ms",   16,
-    tolower(_vmSize) == "standard_m64-16ms",   16, tolower(_vmSize) == "standard_m64-32ms",   32,
-    tolower(_vmSize) == "standard_m128-32ms",  32, tolower(_vmSize) == "standard_m128-64ms",  64,
-    coalesce(toint(extract(@'_[A-Za-z]+(\d+)', 1, _vmSize)), 4)
-)
-| extend _now = now()
-| extend EOLStatus = case(
-    SQLVersion == "SQL Server 2008",                                        "Expired",
-    SQLVersion == "SQL Server 2008 R2",                                     "Expired",
-    SQLVersion == "SQL Server 2012",                                        "Expired",
-    SQLVersion == "SQL Server 2014" and _now >= datetime(2027-07-12),       "Expired",
-    SQLVersion == "SQL Server 2014",                                        "ESU Active",
-    SQLVersion == "SQL Server 2016" and _now >= datetime(2029-07-14),       "Expired",
-    SQLVersion == "SQL Server 2016" and _now >= datetime(2026-07-14),       "ESU Active",
-    SQLVersion == "SQL Server 2016",                                        "Upcoming ESU",
-    SQLVersion == "SQL Server 2017" and _now >= datetime(2030-10-12),       "Expired",
-    SQLVersion == "SQL Server 2017" and _now >= datetime(2027-10-12),       "ESU Active",
-    SQLVersion == "SQL Server 2017",                                        "Supported",
-    SQLVersion == "SQL Server 2019",                                        "Supported",
-    SQLVersion == "SQL Server 2022",                                        "Supported",
-    "Unknown"
-)
-| extend MainstreamEndDate = case(
-    SQLVersion == "SQL Server 2008",    datetime(2012-04-12),
-    SQLVersion == "SQL Server 2008 R2", datetime(2014-07-08),
-    SQLVersion == "SQL Server 2012",    datetime(2017-07-11),
-    SQLVersion == "SQL Server 2014",    datetime(2019-07-09),
-    SQLVersion == "SQL Server 2016",    datetime(2021-07-13),
-    SQLVersion == "SQL Server 2017",    datetime(2022-10-11),
-    SQLVersion == "SQL Server 2019",    datetime(2025-01-08),
-    SQLVersion == "SQL Server 2022",    datetime(2028-01-11),
-    datetime(2099-01-01)
-)
-| extend ESUEndDate = case(
-    SQLVersion == "SQL Server 2008",    datetime(2019-07-09),
-    SQLVersion == "SQL Server 2008 R2", datetime(2019-07-09),
-    SQLVersion == "SQL Server 2012",    datetime(2025-07-08),
-    SQLVersion == "SQL Server 2014",    datetime(2027-07-12),
-    SQLVersion == "SQL Server 2016",    datetime(2029-07-14),
-    SQLVersion == "SQL Server 2017",    datetime(2030-10-12),
-    SQLVersion == "SQL Server 2019",    datetime(2033-01-08),
-    SQLVersion == "SQL Server 2022",    datetime(2036-01-11),
-    datetime(2099-01-01)
-)
-| extend ESUMonthlyCostPerCore = case(
-    (SQLVersion == "SQL Server 2014" or SQLVersion == "SQL Server 2016" or SQLVersion == "SQL Server 2017")
-        and tolower(Edition) contains "enterprise", 540.5,
-    (SQLVersion == "SQL Server 2014" or SQLVersion == "SQL Server 2016" or SQLVersion == "SQL Server 2017")
-        and tolower(Edition) contains "developer",  0.0,
-    SQLVersion == "SQL Server 2014", 139.0,
-    SQLVersion == "SQL Server 2016", 139.0,
-    SQLVersion == "SQL Server 2017", 139.0,
-    0.0
-)
-| extend BillableCores        = iff(vCores < 4, 4, vCores)
-| extend EstimatedMonthlyCost = ESUMonthlyCostPerCore * BillableCores
-| extend _miVCores = iff(vCores < 4, 4, vCores)
-| extend EstSQLMIMonthlyCost = case(
-    tolower(Edition) contains "enterprise", 367.0 * _miVCores,
-    tolower(Edition) contains "developer",   0.0,
-    123.0 * _miVCores
-)
-| extend PatchOpsMonthlyCost = 160.0
-| extend EstSQLMISaving = iff(
-    EstimatedMonthlyCost == 0.0,
-    PatchOpsMonthlyCost,
-    EstimatedMonthlyCost + PatchOpsMonthlyCost - EstSQLMIMonthlyCost
-)
-| project
-    Name = name,
-    ResourceGroup = resourceGroup,
-    SubscriptionId = subscriptionId,
-    Location = location,
-    CloudType,
-    SQLVersion,
-    Edition,
-    vCores,
-    EOLStatus,
-    MainstreamEndDate,
-    ESUEndDate,
-    ESUMonthlyCostPerCore,
-    BillableCores,
-    EstimatedMonthlyCost,
-    EstimatedAnnualCost = EstimatedMonthlyCost * 12,
-    EstimatedThreeYearCost = EstimatedMonthlyCost * 36,
-    PatchOpsMonthlyCost,
-    EstSQLMIMonthlyCost,
-    EstSQLMISaving
-| order by EOLStatus asc, SQLVersion asc, Name asc
-`
-
 	log.Debug().Msg("Executing SQL ESU ARG query")
 
 	subs := make([]*string, 0, len(subscriptions))
@@ -221,7 +76,7 @@ resources
 		subs = append(subs, to.Ptr(subID))
 	}
 
-	result, err := graphClient.Query(ctx, query, subs)
+	result, err := graphClient.Query(ctx, sqlESUQuery, subs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query Azure Resource Graph for SQL ESU resources: %w", err)
 	}

--- a/internal/scanners/plugins/sqlesu/sqlesu.go
+++ b/internal/scanners/plugins/sqlesu/sqlesu.go
@@ -1,0 +1,293 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package sqlesu
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azqr/internal/graph"
+	"github.com/Azure/azqr/internal/models"
+	"github.com/Azure/azqr/internal/plugins"
+	"github.com/Azure/azqr/internal/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/rs/zerolog/log"
+)
+
+// Scanner is an internal plugin that scans SQL Server EOL/ESU status
+type Scanner struct{}
+
+// NewScanner creates a new SQL ESU scanner
+func NewScanner() *Scanner {
+	return &Scanner{}
+}
+
+// GetMetadata returns plugin metadata
+func (s *Scanner) GetMetadata() plugins.PluginMetadata {
+	return plugins.PluginMetadata{
+		Name:        "sql-esu",
+		Version:     "1.0.0",
+		Description: "Analyzes SQL Server End-of-Life and Extended Security Update status",
+		Author:      "Azure Quick Review Team",
+		License:     "MIT",
+		Type:        plugins.PluginTypeInternal,
+		ColumnMetadata: []plugins.ColumnMetadata{
+			{Name: "Name", DataKey: "name", FilterType: plugins.FilterTypeSearch},
+			{Name: "Resource Group", DataKey: "resourceGroup", FilterType: plugins.FilterTypeDropdown},
+			{Name: "Subscription", DataKey: "subscriptionId", FilterType: plugins.FilterTypeDropdown},
+			{Name: "Location", DataKey: "location", FilterType: plugins.FilterTypeDropdown},
+			{Name: "Cloud Type", DataKey: "cloudType", FilterType: plugins.FilterTypeDropdown},
+			{Name: "SQL Version", DataKey: "sqlVersion", FilterType: plugins.FilterTypeDropdown},
+			{Name: "Edition", DataKey: "edition", FilterType: plugins.FilterTypeDropdown},
+			{Name: "vCores", DataKey: "vCores", FilterType: plugins.FilterTypeNone},
+			{Name: "EOL Status", DataKey: "eolStatus", FilterType: plugins.FilterTypeDropdown},
+			{Name: "Mainstream End Date", DataKey: "mainstreamEndDate", FilterType: plugins.FilterTypeNone},
+			{Name: "ESU End Date", DataKey: "esuEndDate", FilterType: plugins.FilterTypeNone},
+			{Name: "ESU Monthly Cost/Core", DataKey: "esuMonthlyCostPerCore", FilterType: plugins.FilterTypeNone},
+			{Name: "Billable Cores", DataKey: "billableCores", FilterType: plugins.FilterTypeNone},
+			{Name: "Estimated Monthly Cost", DataKey: "estimatedMonthlyCost", FilterType: plugins.FilterTypeNone},
+			{Name: "Estimated Annual Cost", DataKey: "estimatedAnnualCost", FilterType: plugins.FilterTypeNone},
+			{Name: "Estimated 3-Year Cost", DataKey: "estimatedThreeYearCost", FilterType: plugins.FilterTypeNone},
+			{Name: "Patch Ops Monthly Cost", DataKey: "patchOpsMonthlyCost", FilterType: plugins.FilterTypeNone},
+			{Name: "Est SQL MI Monthly Cost", DataKey: "estSqlMiMonthlyCost", FilterType: plugins.FilterTypeNone},
+			{Name: "Est SQL MI Monthly Saving", DataKey: "estSqlMiSaving", FilterType: plugins.FilterTypeNone},
+		},
+	}
+}
+
+// Scan executes the plugin and returns table data
+func (s *Scanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscriptions map[string]string, filters *models.Filters) (*plugins.ExternalPluginOutput, error) {
+	models.LogResourceTypeScan("SQL Server EOL/ESU Status")
+
+	graphClient := graph.NewGraphQuery(cred)
+
+	query := `
+resources
+| where type == "microsoft.azurearcdata/sqlserverinstances"
+    or type == "microsoft.sqlvirtualmachine/sqlvirtualmachines"
+| extend SQLVersion = iff(
+    type == "microsoft.azurearcdata/sqlserverinstances",
+    tostring(properties.version),
+    strcat("SQL Server ", substring(tostring(properties.sqlImageOffer), 3, 4))
+)
+| extend Edition = iff(
+    type == "microsoft.azurearcdata/sqlserverinstances",
+    tostring(properties.edition),
+    tostring(properties.sqlImageSku)
+)
+| extend CloudType = iff(
+    type == "microsoft.azurearcdata/sqlserverinstances",
+    "Arc-enabled (On-Prem)",
+    "Azure VM (SQL IaaS)"
+)
+| extend _vmId = iff(type == "microsoft.sqlvirtualmachine/sqlvirtualmachines", tolower(tostring(properties.virtualMachineResourceId)), "")
+| join kind=leftouter (
+    resources
+    | where type == "microsoft.compute/virtualmachines"
+    | project _vmId = tolower(id), _vmSize = tostring(properties.hardwareProfile.vmSize)
+) on _vmId
+| extend vCores = case(
+    type == "microsoft.azurearcdata/sqlserverinstances", coalesce(toint(properties.vCore), 0),
+    tolower(_vmSize) == "standard_d1_v2",      1,  tolower(_vmSize) == "standard_d2_v2",      2,
+    tolower(_vmSize) == "standard_d3_v2",      4,  tolower(_vmSize) == "standard_d4_v2",      8,
+    tolower(_vmSize) == "standard_d5_v2",      16, tolower(_vmSize) == "standard_d11_v2",     2,
+    tolower(_vmSize) == "standard_d12_v2",     4,  tolower(_vmSize) == "standard_d13_v2",     8,
+    tolower(_vmSize) == "standard_d14_v2",     16,
+    tolower(_vmSize) == "standard_ds1_v2",     1,  tolower(_vmSize) == "standard_ds2_v2",     2,
+    tolower(_vmSize) == "standard_ds3_v2",     4,  tolower(_vmSize) == "standard_ds4_v2",     8,
+    tolower(_vmSize) == "standard_ds5_v2",     16, tolower(_vmSize) == "standard_ds11_v2",    2,
+    tolower(_vmSize) == "standard_ds11-1_v2",  1,
+    tolower(_vmSize) == "standard_ds12_v2",    4,  tolower(_vmSize) == "standard_ds12-1_v2",  1,
+    tolower(_vmSize) == "standard_ds12-2_v2",  2,
+    tolower(_vmSize) == "standard_ds13_v2",    8,  tolower(_vmSize) == "standard_ds13-2_v2",  2,
+    tolower(_vmSize) == "standard_ds13-4_v2",  4,
+    tolower(_vmSize) == "standard_ds14_v2",    16, tolower(_vmSize) == "standard_ds14-4_v2",  4,
+    tolower(_vmSize) == "standard_ds14-8_v2",  8,  tolower(_vmSize) == "standard_ds15_v2",    20,
+    tolower(_vmSize) == "standard_g1",         2,  tolower(_vmSize) == "standard_g2",         4,
+    tolower(_vmSize) == "standard_g3",         8,  tolower(_vmSize) == "standard_g4",         16,
+    tolower(_vmSize) == "standard_g5",         32,
+    tolower(_vmSize) == "standard_gs1",        2,  tolower(_vmSize) == "standard_gs2",        4,
+    tolower(_vmSize) == "standard_gs3",        8,  tolower(_vmSize) == "standard_gs4",        16,
+    tolower(_vmSize) == "standard_gs4-4",      4,  tolower(_vmSize) == "standard_gs4-8",      8,
+    tolower(_vmSize) == "standard_gs5",        32, tolower(_vmSize) == "standard_gs5-8",      8,
+    tolower(_vmSize) == "standard_gs5-16",     16,
+    tolower(_vmSize) == "standard_m8ms",       8,  tolower(_vmSize) == "standard_m16ms",      16,
+    tolower(_vmSize) == "standard_m32ts",      32, tolower(_vmSize) == "standard_m32ls",      32,
+    tolower(_vmSize) == "standard_m32ms",      32, tolower(_vmSize) == "standard_m64",        64,
+    tolower(_vmSize) == "standard_m64ms",      64, tolower(_vmSize) == "standard_m64ls",      64,
+    tolower(_vmSize) == "standard_m64s",       64, tolower(_vmSize) == "standard_m128ms",     128,
+    tolower(_vmSize) == "standard_m128s",      128,
+    tolower(_vmSize) == "standard_m8-2ms",     2,  tolower(_vmSize) == "standard_m8-4ms",     4,
+    tolower(_vmSize) == "standard_m16-4ms",    4,  tolower(_vmSize) == "standard_m16-8ms",    8,
+    tolower(_vmSize) == "standard_m32-8ms",    8,  tolower(_vmSize) == "standard_m32-16ms",   16,
+    tolower(_vmSize) == "standard_m64-16ms",   16, tolower(_vmSize) == "standard_m64-32ms",   32,
+    tolower(_vmSize) == "standard_m128-32ms",  32, tolower(_vmSize) == "standard_m128-64ms",  64,
+    coalesce(toint(extract(@'_[A-Za-z]+(\d+)', 1, _vmSize)), 4)
+)
+| extend _now = now()
+| extend EOLStatus = case(
+    SQLVersion == "SQL Server 2008",                                        "Expired",
+    SQLVersion == "SQL Server 2008 R2",                                     "Expired",
+    SQLVersion == "SQL Server 2012",                                        "Expired",
+    SQLVersion == "SQL Server 2014" and _now >= datetime(2027-07-12),       "Expired",
+    SQLVersion == "SQL Server 2014",                                        "ESU Active",
+    SQLVersion == "SQL Server 2016" and _now >= datetime(2029-07-14),       "Expired",
+    SQLVersion == "SQL Server 2016" and _now >= datetime(2026-07-14),       "ESU Active",
+    SQLVersion == "SQL Server 2016",                                        "Upcoming ESU",
+    SQLVersion == "SQL Server 2017" and _now >= datetime(2030-10-12),       "Expired",
+    SQLVersion == "SQL Server 2017" and _now >= datetime(2027-10-12),       "ESU Active",
+    SQLVersion == "SQL Server 2017",                                        "Supported",
+    SQLVersion == "SQL Server 2019",                                        "Supported",
+    SQLVersion == "SQL Server 2022",                                        "Supported",
+    "Unknown"
+)
+| extend MainstreamEndDate = case(
+    SQLVersion == "SQL Server 2008",    datetime(2012-04-12),
+    SQLVersion == "SQL Server 2008 R2", datetime(2014-07-08),
+    SQLVersion == "SQL Server 2012",    datetime(2017-07-11),
+    SQLVersion == "SQL Server 2014",    datetime(2019-07-09),
+    SQLVersion == "SQL Server 2016",    datetime(2021-07-13),
+    SQLVersion == "SQL Server 2017",    datetime(2022-10-11),
+    SQLVersion == "SQL Server 2019",    datetime(2025-01-08),
+    SQLVersion == "SQL Server 2022",    datetime(2028-01-11),
+    datetime(2099-01-01)
+)
+| extend ESUEndDate = case(
+    SQLVersion == "SQL Server 2008",    datetime(2019-07-09),
+    SQLVersion == "SQL Server 2008 R2", datetime(2019-07-09),
+    SQLVersion == "SQL Server 2012",    datetime(2025-07-08),
+    SQLVersion == "SQL Server 2014",    datetime(2027-07-12),
+    SQLVersion == "SQL Server 2016",    datetime(2029-07-14),
+    SQLVersion == "SQL Server 2017",    datetime(2030-10-12),
+    SQLVersion == "SQL Server 2019",    datetime(2033-01-08),
+    SQLVersion == "SQL Server 2022",    datetime(2036-01-11),
+    datetime(2099-01-01)
+)
+| extend ESUMonthlyCostPerCore = case(
+    (SQLVersion == "SQL Server 2014" or SQLVersion == "SQL Server 2016" or SQLVersion == "SQL Server 2017")
+        and tolower(Edition) contains "enterprise", 540.5,
+    (SQLVersion == "SQL Server 2014" or SQLVersion == "SQL Server 2016" or SQLVersion == "SQL Server 2017")
+        and tolower(Edition) contains "developer",  0.0,
+    SQLVersion == "SQL Server 2014", 139.0,
+    SQLVersion == "SQL Server 2016", 139.0,
+    SQLVersion == "SQL Server 2017", 139.0,
+    0.0
+)
+| extend BillableCores        = iff(vCores < 4, 4, vCores)
+| extend EstimatedMonthlyCost = ESUMonthlyCostPerCore * BillableCores
+| extend _miVCores = iff(vCores < 4, 4, vCores)
+| extend EstSQLMIMonthlyCost = case(
+    tolower(Edition) contains "enterprise", 367.0 * _miVCores,
+    tolower(Edition) contains "developer",   0.0,
+    123.0 * _miVCores
+)
+| extend PatchOpsMonthlyCost = 160.0
+| extend EstSQLMISaving = iff(
+    EstimatedMonthlyCost == 0.0,
+    PatchOpsMonthlyCost,
+    EstimatedMonthlyCost + PatchOpsMonthlyCost - EstSQLMIMonthlyCost
+)
+| project
+    Name = name,
+    ResourceGroup = resourceGroup,
+    SubscriptionId = subscriptionId,
+    Location = location,
+    CloudType,
+    SQLVersion,
+    Edition,
+    vCores,
+    EOLStatus,
+    MainstreamEndDate,
+    ESUEndDate,
+    ESUMonthlyCostPerCore,
+    BillableCores,
+    EstimatedMonthlyCost,
+    EstimatedAnnualCost = EstimatedMonthlyCost * 12,
+    EstimatedThreeYearCost = EstimatedMonthlyCost * 36,
+    PatchOpsMonthlyCost,
+    EstSQLMIMonthlyCost,
+    EstSQLMISaving
+| order by EOLStatus asc, SQLVersion asc, Name asc
+`
+
+	log.Debug().Msg("Executing SQL ESU ARG query")
+
+	subs := make([]*string, 0, len(subscriptions))
+	for subID := range subscriptions {
+		if filters.Azqr.IsSubscriptionExcluded(subID) {
+			continue
+		}
+		subs = append(subs, to.Ptr(subID))
+	}
+
+	result, err := graphClient.Query(ctx, query, subs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query Azure Resource Graph for SQL ESU resources: %w", err)
+	}
+
+	// Initialize table with headers
+	table := [][]string{
+		{
+			"Name", "Resource Group", "Subscription", "Location", "Cloud Type",
+			"SQL Version", "Edition", "vCores", "EOL Status",
+			"Mainstream End Date", "ESU End Date",
+			"ESU Monthly Cost/Core", "Billable Cores",
+			"Estimated Monthly Cost", "Estimated Annual Cost", "Estimated 3-Year Cost",
+			"Patch Ops Monthly Cost",
+			"Est SQL MI Monthly Cost", "Est SQL MI Monthly Saving",
+		},
+	}
+
+	if result.Data != nil {
+		for _, row := range result.Data {
+			m := row.(map[string]interface{})
+
+			subscription := to.String(m["SubscriptionId"])
+			if filters.Azqr.IsSubscriptionExcluded(subscription) {
+				continue
+			}
+
+			name := to.String(m["Name"])
+			if filters.Azqr.IsServiceExcluded(name) {
+				continue
+			}
+
+			table = append(table, []string{
+				name,
+				to.String(m["ResourceGroup"]),
+				subscription,
+				to.String(m["Location"]),
+				to.String(m["CloudType"]),
+				to.String(m["SQLVersion"]),
+				to.String(m["Edition"]),
+				to.String(m["vCores"]),
+				to.String(m["EOLStatus"]),
+				to.String(m["MainstreamEndDate"]),
+				to.String(m["ESUEndDate"]),
+				to.String(m["ESUMonthlyCostPerCore"]),
+				to.String(m["BillableCores"]),
+				to.String(m["EstimatedMonthlyCost"]),
+				to.String(m["EstimatedAnnualCost"]),
+				to.String(m["EstimatedThreeYearCost"]),
+				to.String(m["PatchOpsMonthlyCost"]),
+				to.String(m["EstSQLMIMonthlyCost"]),
+				to.String(m["EstSQLMISaving"]),
+			})
+		}
+	}
+
+	log.Info().Msgf("SQL ESU scan completed with %d resources", len(table)-1)
+
+	return &plugins.ExternalPluginOutput{
+		Metadata:    s.GetMetadata(),
+		SheetName:   "SQL ESU",
+		Description: "SQL Server End-of-Life and Extended Security Update status with cost analysis",
+		Table:       table,
+	}, nil
+}
+
+// init registers the plugin automatically
+func init() {
+	plugins.RegisterInternalPlugin("sql-esu", NewScanner())
+}

--- a/internal/scanners/plugins/sqlesu/sqlesu.go
+++ b/internal/scanners/plugins/sqlesu/sqlesu.go
@@ -31,7 +31,7 @@ func NewScanner() *Scanner {
 func (s *Scanner) GetMetadata() plugins.PluginMetadata {
 	return plugins.PluginMetadata{
 		Name:        "sql-esu",
-		Version:     "1.0.0",
+		Version:     "0.1.0-beta",
 		Description: "Analyzes SQL Server End-of-Life and Extended Security Update status",
 		Author:      "Azure Quick Review Team",
 		License:     "MIT",
@@ -47,6 +47,7 @@ func (s *Scanner) GetMetadata() plugins.PluginMetadata {
 			{Name: "vCores", DataKey: "vCores", FilterType: plugins.FilterTypeNone},
 			{Name: "EOL Status", DataKey: "eolStatus", FilterType: plugins.FilterTypeDropdown},
 			{Name: "Mainstream End Date", DataKey: "mainstreamEndDate", FilterType: plugins.FilterTypeNone},
+			{Name: "ESU Start Date", DataKey: "esuStartDate", FilterType: plugins.FilterTypeNone},
 			{Name: "ESU End Date", DataKey: "esuEndDate", FilterType: plugins.FilterTypeNone},
 			{Name: "ESU Monthly Cost/Core", DataKey: "esuMonthlyCostPerCore", FilterType: plugins.FilterTypeNone},
 			{Name: "Billable Cores", DataKey: "billableCores", FilterType: plugins.FilterTypeNone},
@@ -54,29 +55,27 @@ func (s *Scanner) GetMetadata() plugins.PluginMetadata {
 			{Name: "Estimated Annual Cost", DataKey: "estimatedAnnualCost", FilterType: plugins.FilterTypeNone},
 			{Name: "Estimated 3-Year Cost", DataKey: "estimatedThreeYearCost", FilterType: plugins.FilterTypeNone},
 			{Name: "Patch Ops Monthly Cost", DataKey: "patchOpsMonthlyCost", FilterType: plugins.FilterTypeNone},
+			{Name: "Patch Ops Annual Cost", DataKey: "patchOpsAnnualCost", FilterType: plugins.FilterTypeNone},
+			{Name: "Patch Ops 3-Year Cost", DataKey: "patchOpsThreeYearCost", FilterType: plugins.FilterTypeNone},
 			{Name: "Est SQL MI Monthly Cost", DataKey: "estSqlMiMonthlyCost", FilterType: plugins.FilterTypeNone},
+			{Name: "Est SQL MI Annual Cost", DataKey: "estSqlMiAnnualCost", FilterType: plugins.FilterTypeNone},
+			{Name: "Est SQL MI 3-Year Cost", DataKey: "estSqlMiThreeYearCost", FilterType: plugins.FilterTypeNone},
 			{Name: "Est SQL MI Monthly Saving", DataKey: "estSqlMiSaving", FilterType: plugins.FilterTypeNone},
+			{Name: "Est SQL MI Annual Saving", DataKey: "estSqlMiAnnualSaving", FilterType: plugins.FilterTypeNone},
+			{Name: "Est SQL MI 3-Year Saving", DataKey: "estSqlMiThreeYearSaving", FilterType: plugins.FilterTypeNone},
 		},
 	}
 }
 
 // Scan executes the plugin and returns table data
-func (s *Scanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscriptions map[string]string, filters *models.Filters) (*plugins.ExternalPluginOutput, error) {
+func (s *Scanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscriptions map[string]string, params *models.ScanParams) ([]plugins.ExternalPluginOutput, error) {
 	models.LogResourceTypeScan("SQL Server EOL/ESU Status")
 
 	graphClient := graph.NewGraphQuery(cred)
 
 	log.Debug().Msg("Executing SQL ESU ARG query")
 
-	subs := make([]*string, 0, len(subscriptions))
-	for subID := range subscriptions {
-		if filters.Azqr.IsSubscriptionExcluded(subID) {
-			continue
-		}
-		subs = append(subs, to.Ptr(subID))
-	}
-
-	result, err := graphClient.Query(ctx, sqlESUQuery, subs)
+	result, err := graphClient.Query(ctx, sqlESUQuery, subscriptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query Azure Resource Graph for SQL ESU resources: %w", err)
 	}
@@ -86,11 +85,12 @@ func (s *Scanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscri
 		{
 			"Name", "Resource Group", "Subscription", "Location", "Cloud Type",
 			"SQL Version", "Edition", "vCores", "EOL Status",
-			"Mainstream End Date", "ESU End Date",
+			"Mainstream End Date", "ESU Start Date", "ESU End Date",
 			"ESU Monthly Cost/Core", "Billable Cores",
 			"Estimated Monthly Cost", "Estimated Annual Cost", "Estimated 3-Year Cost",
-			"Patch Ops Monthly Cost",
-			"Est SQL MI Monthly Cost", "Est SQL MI Monthly Saving",
+			"Patch Ops Monthly Cost", "Patch Ops Annual Cost", "Patch Ops 3-Year Cost",
+			"Est SQL MI Monthly Cost", "Est SQL MI Annual Cost", "Est SQL MI 3-Year Cost",
+			"Est SQL MI Monthly Saving", "Est SQL MI Annual Saving", "Est SQL MI 3-Year Saving",
 		},
 	}
 
@@ -99,7 +99,7 @@ func (s *Scanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscri
 			m := row.(map[string]interface{})
 
 			subscription := to.String(m["SubscriptionId"])
-			if filters.Azqr.IsSubscriptionExcluded(subscription) {
+			if params.Filters.Azqr.IsSubscriptionExcluded(subscription) {
 				continue
 			}
 
@@ -114,6 +114,7 @@ func (s *Scanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscri
 				to.String(m["vCores"]),
 				to.String(m["EOLStatus"]),
 				to.String(m["MainstreamEndDate"]),
+				to.String(m["ESUStartDate"]),
 				to.String(m["ESUEndDate"]),
 				to.String(m["ESUMonthlyCostPerCore"]),
 				to.String(m["BillableCores"]),
@@ -121,20 +122,26 @@ func (s *Scanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscri
 				to.String(m["EstimatedAnnualCost"]),
 				to.String(m["EstimatedThreeYearCost"]),
 				to.String(m["PatchOpsMonthlyCost"]),
+				to.String(m["PatchOpsAnnualCost"]),
+				to.String(m["PatchOpsThreeYearCost"]),
 				to.String(m["EstSQLMIMonthlyCost"]),
+				to.String(m["EstSQLMIAnnualCost"]),
+				to.String(m["EstSQLMIThreeYearCost"]),
 				to.String(m["EstSQLMISaving"]),
+				to.String(m["EstSQLMIAnnualSaving"]),
+				to.String(m["EstSQLMIThreeYearSaving"]),
 			})
 		}
 	}
 
 	log.Info().Msgf("SQL ESU scan completed with %d resources", len(table)-1)
 
-	return &plugins.ExternalPluginOutput{
+	return []plugins.ExternalPluginOutput{{
 		Metadata:    s.GetMetadata(),
 		SheetName:   "SQL ESU",
 		Description: "SQL Server End-of-Life and Extended Security Update status with cost analysis",
 		Table:       table,
-	}, nil
+	}}, nil
 }
 
 // init registers the plugin automatically


### PR DESCRIPTION
# Description

Adds a new internal plugin (`sql-esu`) that queries Azure Resource Graph for Arc-enabled SQL Server instances and SQL Virtual Machines, reporting their End-of-Life status, ESU licensing costs, and SQL Managed Instance migration savings.

The plugin uses a single ARG query that:
- Covers both `microsoft.azurearcdata/sqlserverinstances` and `microsoft.sqlvirtualmachine/sqlvirtualmachines`
- Resolves vCores from VM size (including legacy SKU lookup table and modern regex fallback)
- Computes EOL status dynamically using `now()` so statuses flip on the correct calendar date
- Calculates ESU costs by edition (Enterprise $540.50/core, Standard $139/core, Developer $0) with 4-core minimum
- Estimates SQL MI migration savings (GP $123/vCore, BC $367/vCore) plus patch ops overhead ($160/month)

## Issue reference

Closes #875

## Checklist

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing