### PR TITLE
feat: add --preview flag to install scripts for pre-release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ wps | Microsoft.SignalRService/webPubSub
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/azure/azqr/main/scripts/install.sh)"
 ```
 
+To install the latest preview (pre-release) version:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/azure/azqr/main/scripts/install.sh)" -- --preview
+```
+
 ### Windows
 
 ```console
@@ -188,6 +194,11 @@ winget install azqr
 Or via PowerShell:
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/azure/azqr/main/scripts/install.ps1'))
+```
+
+To install the latest preview (pre-release) version via PowerShell:
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "& { $(iwr -useb 'https://raw.githubusercontent.com/azure/azqr/main/scripts/install.ps1') } -Preview"
 ```
 
 ### macOS

--- a/docs/content/en/docs/Install/_index.md
+++ b/docs/content/en/docs/Install/_index.md
@@ -10,6 +10,12 @@ description: Learn how to install Azure Quick Review (azqr)
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/azure/azqr/main/scripts/install.sh)"
 ```
 
+To install the latest preview (pre-release) version:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/azure/azqr/main/scripts/install.sh)" -- --preview
+```
+
 ## Install on Windows
 
 Use `winget`:
@@ -22,6 +28,12 @@ or download the executable file:
 
 ```
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/azure/azqr/main/scripts/install.ps1'))
+```
+
+To install the latest preview (pre-release) version:
+
+```
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "& { $(iwr -useb 'https://raw.githubusercontent.com/azure/azqr/main/scripts/install.ps1') } -Preview"
 ```
 
 ## Install on Mac

--- a/jumpstart_drops/azqr-tutorial/_index.md
+++ b/jumpstart_drops/azqr-tutorial/_index.md
@@ -41,6 +41,12 @@ Before you begin the installation, ensure you have the following prerequisites:
    bash -c "$(curl -fsSL https://raw.githubusercontent.com/azure/azqr/main/scripts/install.sh)"
    ```
 
+   To install the latest preview (pre-release) version:
+
+   ```bash
+   bash -c "$(curl -fsSL https://raw.githubusercontent.com/azure/azqr/main/scripts/install.sh)" -- --preview
+   ```
+
 ### Installation on Windows
 
 1. Open your command prompt or PowerShell.
@@ -54,6 +60,12 @@ Before you begin the installation, ensure you have the following prerequisites:
 
    ```
    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/azure/azqr/main/scripts/install.ps1'))
+   ```
+
+   To install the latest preview (pre-release) version:
+
+   ```
+   Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "& { $(iwr -useb 'https://raw.githubusercontent.com/azure/azqr/main/scripts/install.ps1') } -Preview"
    ```
 
 ### Installation on Mac

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,3 +1,7 @@
+param(
+    [switch]$Preview
+)
+
 if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") {
     $arch = "amd64"
 } elseif ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
@@ -7,7 +11,19 @@ if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") {
     exit
 }
 
-$latest_azqr=$(iwr https://api.github.com/repos/Azure/azqr/releases/latest).content | convertfrom-json | Select-Object -ExpandProperty tag_name
+if ($Preview) {
+    $releases = (iwr https://api.github.com/repos/Azure/azqr/releases).content | ConvertFrom-Json
+    $preRelease = $releases | Where-Object { $_.prerelease -eq $true } | Select-Object -First 1
+    if (-not $preRelease) {
+        Write-Host "No preview version available."
+        exit 1
+    }
+    $latest_azqr = $preRelease.tag_name
+    Write-Host "Installing preview version: $latest_azqr"
+} else {
+    $latest_azqr = (iwr https://api.github.com/repos/Azure/azqr/releases/latest).content | ConvertFrom-Json | Select-Object -ExpandProperty tag_name
+}
+
 iwr https://github.com/Azure/azqr/releases/download/$latest_azqr/azqr-win-$arch.zip -OutFile azqr.zip
 Expand-Archive -Path azqr.zip -DestinationPath ./azqr_bin
 Get-ChildItem -Path ./azqr_bin -Recurse -File | ForEach-Object { Move-Item -Path $_.FullName -Destination . -Force }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,30 @@
 #!/bin/bash
 
+PREVIEW=false
+
+usage() {
+    echo "Usage: $0 [--preview]"
+    echo "  --preview    Install the latest preview (pre-release) version"
+    echo "  --help       Show this help message"
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --preview)
+            PREVIEW=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
 if ! command -v jq &> /dev/null || ! command -v unzip &> /dev/null || ! command -v wget &> /dev/null
 then
     echo "jq, unzip or wget could not be found, please install them."
@@ -13,7 +38,17 @@ else
     arch="amd64"
 fi
 
-latest_azqr=$(curl -sL https://api.github.com/repos/Azure/azqr/releases/latest | jq -r ".tag_name" | cut -c1-)
+if [ "$PREVIEW" = true ]; then
+    latest_azqr=$(curl -sL https://api.github.com/repos/Azure/azqr/releases | jq -r '[.[] | select(.prerelease == true)] | first | .tag_name')
+    if [ "$latest_azqr" == "null" ] || [ -z "$latest_azqr" ]; then
+        echo "No preview version available."
+        exit 1
+    fi
+    echo "Installing preview version: $latest_azqr"
+else
+    latest_azqr=$(curl -sL https://api.github.com/repos/Azure/azqr/releases/latest | jq -r ".tag_name" | cut -c1-)
+fi
+
 wget https://github.com/Azure/azqr/releases/download/$latest_azqr/azqr-linux-$arch.zip -O azqr.zip
 unzip -uj -qq azqr.zip
 rm azqr.zip


### PR DESCRIPTION
Closes #888

## Summary

Add support for installing preview (pre-release) versions of azqr via the install scripts.

## Changes

### Scripts
- **`scripts/install.sh`**: Added `--preview` and `--help` flags. When `--preview` is passed, queries `/releases` API and filters for `prerelease == true` with jq.
- **`scripts/install.ps1`**: Added `-Preview` switch parameter. When passed, queries `/releases` API and filters for pre-release versions.

Both scripts exit gracefully with a clear error message if no pre-release version is available.

### Documentation
- Updated `docs/content/en/docs/Install/_index.md` with preview install examples
- Updated `README.md` with preview install examples
- Updated `jumpstart_drops/azqr-tutorial/_index.md` with preview install examples

## Usage

**Linux:**
```bash
bash -c "$(curl -fsSL https://raw.githubusercontent.com/azure/azqr/main/scripts/install.sh)" -- --preview
```

**Windows (PowerShell):**
```powershell
Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "& { $(iwr -useb 'https://raw.githubusercontent.com/azure/azqr/main/scripts/install.ps1') } -Preview"
```

## Backward Compatibility

Default behavior (no flag) is unchanged — scripts still install the latest stable release.