### PR TITLE
feat(mcp): add sql-esu and region-selection plugin tools and prompts

### DIFF
--- a/internal/mcpserver/prompt_region_selection.go
+++ b/internal/mcpserver/prompt_region_selection.go
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func handleRegionSelectionPrompt() func(context.Context, mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	return func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		targetRegions := request.Params.Arguments["target_regions"]
+		prompt := `Analyze optimal Azure region selection for your workloads.
+
+Please:
+1. Use the scan-region-selection tool with options: {"target-regions": "%s"} to retrieve region analysis data
+2. Analyze the results focusing on:
+   - Service and SKU availability across target regions
+   - Network latency between source and target regions
+   - Cost differences between regions
+   - Recommendation scores and quality indicators
+3. Provide actionable recommendations for:
+   - Best target regions based on availability, latency, and cost
+   - Resources or SKUs that may not be available in target regions
+   - Multi-region architecture considerations
+   - Trade-offs between latency, cost, and service coverage
+`
+		promptText := fmt.Sprintf(prompt, targetRegions)
+		promptMessage := mcp.NewPromptMessage(mcp.RoleUser, mcp.NewTextContent(promptText))
+
+		return mcp.NewGetPromptResult(
+			"analyze region selection",
+			[]mcp.PromptMessage{promptMessage},
+		), nil
+	}
+}

--- a/internal/mcpserver/prompt_sql_esu.go
+++ b/internal/mcpserver/prompt_sql_esu.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package mcpserver
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func handleSQLESUPrompt() func(context.Context, mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+	return func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		prompt := `Analyze SQL Server End-of-Life and Extended Security Update (ESU) status.
+
+Please:
+1. Use the scan-sql-esu tool to retrieve SQL Server EOL/ESU data
+2. Analyze the results focusing on:
+   - SQL Server instances approaching or past end-of-life
+   - ESU coverage and cost implications
+   - Estimated costs for ESU vs migration to SQL Managed Instance
+   - Potential savings from modernization
+3. Provide actionable recommendations for:
+   - Prioritizing migrations based on cost and risk
+   - Optimizing ESU spend where migration is not immediately feasible
+   - Planning timeline for end-of-support transitions
+`
+
+		promptMessage := mcp.NewPromptMessage(mcp.RoleUser, mcp.NewTextContent(prompt))
+
+		return mcp.NewGetPromptResult(
+			"analyze SQL ESU status",
+			[]mcp.PromptMessage{promptMessage},
+		), nil
+	}
+}

--- a/internal/mcpserver/prompts.go
+++ b/internal/mcpserver/prompts.go
@@ -40,4 +40,21 @@ func RegisterPrompts(s *server.MCPServer) {
 	)
 
 	s.AddPrompt(zoneMappingPrompt, handleZoneMappingPrompt())
+
+	// SQL ESU Plugin Prompt
+	sqlESUPrompt := mcp.NewPrompt(
+		"analyze_sql_esu",
+		mcp.WithPromptDescription("Analyze SQL Server End-of-Life and Extended Security Update status with cost analysis"),
+	)
+
+	s.AddPrompt(sqlESUPrompt, handleSQLESUPrompt())
+
+	// Region Selection Plugin Prompt
+	regionSelectionPrompt := mcp.NewPrompt(
+		"analyze_region_selection",
+		mcp.WithPromptDescription("Analyze optimal Azure region selection based on service availability, latency, and cost"),
+		mcp.WithArgument("target_regions", mcp.RequiredArgument(), mcp.ArgumentDescription("One or more target Azure regions to analyze, comma-separated (e.g. eastus,westeurope)")),
+	)
+
+	s.AddPrompt(regionSelectionPrompt, handleRegionSelectionPrompt())
 }

--- a/internal/mcpserver/tool_plugin.go
+++ b/internal/mcpserver/tool_plugin.go
@@ -29,6 +29,13 @@ func scanPluginHandler(pluginName string) func(context.Context, mcp.CallToolRequ
 		params.Json = true
 		params.OutputName = fmt.Sprintf("%s/azqr_%s_results", currentDir, pluginName)
 
+		// Apply plugin stage options if provided (e.g. target-regions for region-selection)
+		if len(args.Options) > 0 {
+			if err := params.Stages.SetStageOptions(models.StageNamePlugin, args.Options); err != nil {
+				log.Fatal().Err(err).Msg("failed applying plugin stage options")
+			}
+		}
+
 		// Enable the specific plugin for execution
 		params.EnabledInternalPlugins = map[string]bool{
 			pluginName: true,

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -64,6 +64,50 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(zoneMappingTool, mcp.NewTypedToolHandler(scanPluginHandler("zone-mapping")))
 
+	// Plugin Tools: SQL ESU
+	sqlESUTool := mcp.NewTool("scan-sql-esu",
+		withBasicOptions(
+			mcp.WithDescription(
+				`Analyze SQL Server End-of-Life and Extended Security Update (ESU) status.
+
+				This tool scans SQL Server instances across your Azure subscriptions and provides:
+				- SQL Server version and edition details
+				- End-of-life status and dates
+				- ESU coverage period and costs per core
+				- Estimated monthly, annual, and 3-year ESU costs
+				- Patch operations cost comparison
+				- SQL Managed Instance migration cost estimates and potential savings
+
+				Useful for planning SQL Server modernization and understanding ESU financial impact.
+				Results are saved to Excel/JSON files and returned with resource URIs for download.`),
+		)...,
+	)
+	s.AddTool(sqlESUTool, mcp.NewTypedToolHandler(scanPluginHandler("sql-esu")))
+
+	// Plugin Tools: Region Selection
+	regionSelectionTool := mcp.NewTool("scan-region-selection",
+		withBasicOptions(
+			mcp.WithDescription(
+				`Analyze optimal Azure region selection based on service availability, network latency, and cost.
+
+				This tool evaluates target regions for your workloads and provides:
+				- Resource type availability comparison between source and target regions
+				- SKU availability analysis (available, unavailable, restricted)
+				- Network latency estimates between regions
+				- Cost difference percentages
+				- Recommendation scores with quality indicators
+				- Detailed lists of missing resource types and unavailable SKUs
+
+				Useful for multi-region planning, disaster recovery site selection, and workload migration.
+				Results are saved to Excel/JSON files and returned with resource URIs for download.`),
+			mcp.WithObject("options",
+				mcp.Required(),
+				mcp.Description("Plugin options. Use 'target-regions' (comma-separated string) to specify which Azure regions to analyze (e.g., {\"target-regions\": \"eastus,westeurope\"})."),
+			),
+		)...,
+	)
+	s.AddTool(regionSelectionTool, mcp.NewTypedToolHandler(scanPluginHandler("region-selection")))
+
 	scan := mcp.NewTool("scan",
 		withBasicOptions(
 			mcp.WithDescription(

--- a/internal/models/scan_params.go
+++ b/internal/models/scan_params.go
@@ -34,9 +34,10 @@ type (
 	}
 
 	PluginScanArgs struct {
-		Subscriptions  []string `json:"subscriptions,omitempty"`
-		ResourceGroups []string `json:"resourceGroups,omitempty"`
-		Mask           *bool    `json:"mask,omitempty"`
+		Subscriptions  []string       `json:"subscriptions,omitempty"`
+		ResourceGroups []string       `json:"resourceGroups,omitempty"`
+		Mask           *bool          `json:"mask,omitempty"`
+		Options        map[string]any `json:"options,omitempty"`
 	}
 )
 

--- a/internal/renderers/csv/csv.go
+++ b/internal/renderers/csv/csv.go
@@ -84,10 +84,11 @@ func CreateCsvReport(data *renderers.ReportData) {
 	}
 
 	// Render external plugin results
+	// Use SheetName (not PluginName) so that plugins returning multiple sheets
+	// (e.g. region-selection) each get their own CSV file instead of overwriting.
 	for _, result := range data.PluginResults {
 		if len(result.Table) > 0 {
-			// Use plugin name for the CSV filename extension
-			writeData(result.Table, data.OutputFileName, fmt.Sprintf("plugin_%s", result.PluginName))
+			writeData(result.Table, data.OutputFileName, fmt.Sprintf("plugin_%s", result.SheetName))
 		}
 	}
 }

--- a/internal/renderers/csv/csv_test.go
+++ b/internal/renderers/csv/csv_test.go
@@ -124,8 +124,8 @@ func TestCreateCsvReportWithPlugins(t *testing.T) {
 
 	// Verify plugin CSV files were created
 	expectedPluginFiles := []string{
-		"test_report_plugins.plugin_test-plugin.csv",
-		"test_report_plugins.plugin_another-plugin.csv",
+		"test_report_plugins.plugin_TestSheet.csv",
+		"test_report_plugins.plugin_AnotherSheet.csv",
 	}
 
 	for _, filename := range expectedPluginFiles {

--- a/internal/renderers/json/json.go
+++ b/internal/renderers/json/json.go
@@ -76,16 +76,21 @@ func buildConsolidatedReport(data *renderers.ReportData) map[string]interface{} 
 
 	// Add external plugin results
 	if len(data.PluginResults) > 0 {
-		plugins := make(map[string]interface{})
+		// Use a slice so that plugins returning multiple sheets (e.g. region-selection)
+		// are all preserved. A map keyed by PluginName would silently overwrite
+		// earlier sheets when multiple results share the same plugin name.
+		var pluginsList []interface{}
 		for _, result := range data.PluginResults {
+			dataKey := strcase.ToLowerCamel(result.SheetName)
 			pluginData := map[string]interface{}{
-				"description": result.Description,
+				"pluginName":  result.PluginName,
 				"sheetName":   result.SheetName,
-				"data":        convertToJSON(result.Table),
+				"description": result.Description,
+				dataKey:       convertToJSON(result.Table),
 			}
-			plugins[result.PluginName] = pluginData
+			pluginsList = append(pluginsList, pluginData)
 		}
-		consolidatedReport["externalPlugins"] = plugins
+		consolidatedReport["externalPlugins"] = pluginsList
 	}
 
 	return consolidatedReport
@@ -136,7 +141,7 @@ func writeData(data map[string]interface{}, filename string) {
 
 	_, err = f.Write(js)
 	if err != nil {
-		_ = f.Close() // Close the file before exiting to ensure cleanup
+		_ = f.Close()                                   // Close the file before exiting to ensure cleanup
 		log.Fatal().Err(err).Msg("error writing json:") //nolint:gocritic // File is explicitly closed above
 	}
 }

--- a/internal/renderers/json/json_test.go
+++ b/internal/renderers/json/json_test.go
@@ -206,6 +206,16 @@ func TestCreateJsonReportWithPlugins(t *testing.T) {
 					{"Value1", "Value2"},
 				},
 			},
+			// Second sheet from the same plugin — ensures multi-sheet plugins are not truncated
+			{
+				PluginName:  "test-plugin",
+				Description: "Test Plugin Sheet 2",
+				SheetName:   "TestSheet2",
+				Table: [][]string{
+					{"ColA", "ColB"},
+					{"Row1A", "Row1B"},
+				},
+			},
 		},
 	}
 
@@ -224,9 +234,37 @@ func TestCreateJsonReportWithPlugins(t *testing.T) {
 		t.Errorf("Created file contains invalid JSON: %v", err)
 	}
 
-	// Verify plugin data exists
-	if _, exists := result["externalPlugins"]; !exists {
+	// Verify plugin data exists and is a slice containing all sheets
+	rawPlugins, exists := result["externalPlugins"]
+	if !exists {
 		t.Error("Expected 'externalPlugins' key not found in JSON output")
+	}
+	pluginSlice, ok := rawPlugins.([]interface{})
+	if !ok {
+		t.Errorf("externalPlugins should be an array, got %T", rawPlugins)
+	} else if len(pluginSlice) != 2 {
+		t.Errorf("externalPlugins should contain 2 entries (one per sheet), got %d", len(pluginSlice))
+	} else {
+		// Verify each entry uses the camelCased sheet name as the data key (not generic "data")
+		for i, entry := range pluginSlice {
+			entryMap, ok := entry.(map[string]interface{})
+			if !ok {
+				t.Errorf("externalPlugins[%d] should be an object, got %T", i, entry)
+				continue
+			}
+			sheetName, _ := entryMap["sheetName"].(string)
+			// Expect the data key to be the camelCased sheet name, not "data"
+			dataKey := "testSheet"
+			if i == 1 {
+				dataKey = "testSheet2"
+			}
+			if _, hasDataKey := entryMap[dataKey]; !hasDataKey {
+				t.Errorf("externalPlugins[%d] (sheetName=%q) should have key %q, got keys: %v", i, sheetName, dataKey, mapKeys(entryMap))
+			}
+			if _, hasGenericData := entryMap["data"]; hasGenericData {
+				t.Errorf("externalPlugins[%d] should not have generic 'data' key", i)
+			}
+		}
 	}
 
 	// Verify that disabled features are NOT in the output
@@ -249,4 +287,12 @@ func TestCreateJsonReportWithPlugins(t *testing.T) {
 			t.Errorf("Key %s should not be present when feature is disabled", key)
 		}
 	}
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
## Why

Two gaps introduced by the recently added `sql-esu` and `region-selection` internal plugins:

1. Neither plugin was registered in the MCP server, making them inaccessible to MCP clients.
2. Plugins that return multiple sheets (like `region-selection`) silently lost all but the last sheet in CSV and JSON output because both renderers used `PluginName` as a key, causing collisions.

## What changed

### MCP server (closes #891)

- New tools: `scan-sql-esu` and `scan-region-selection` (with required `options` object; pass `target-regions` as a comma-separated string)
- New prompts: `analyze_sql_esu` and `analyze_region_selection` (`analyze_region_selection` accepts a required `target_regions` argument and injects it into the tool call)
- `PluginScanArgs` gains `Options map[string]any`; `scanPluginHandler` applies these options to the plugin stage config so the region-selection plugin receives `target-regions` via its existing stage-options path

### Renderers (closes #892)

- **CSV**: switched filename suffix from `PluginName` to `SheetName` so each sheet gets its own file
- **JSON**: replaced the `map[string]interface{}` keyed by `PluginName` with a `[]interface{}` slice, preserving all sheets from multi-sheet plugins
