### PR TITLE
refactor(region): simplify and fix region selection plugin

### DIFF
--- a/cmd/azqr/commands/scan.go
+++ b/cmd/azqr/commands/scan.go
@@ -6,6 +6,8 @@
 package commands
 
 import (
+	"strings"
+
 	"github.com/Azure/azqr/internal/models"
 	"github.com/Azure/azqr/internal/pipeline"
 	"github.com/Azure/azqr/internal/profiling"
@@ -146,6 +148,14 @@ func scanWithPlugin(cmd *cobra.Command, scannerKeys []string, pluginName string)
 	}
 
 	stageConfigs := models.NewStageConfigs()
+
+	// Bridge plugin-specific flags into stage options so plugins can read them
+	// via params.Stages.GetStageOptions without relying on package-level globals.
+	if targetRegions, _ := cmd.Flags().GetStringSlice("target-regions"); len(targetRegions) > 0 {
+		_ = stageConfigs.SetStageOptions(models.StageNamePlugin, map[string]any{
+			"target-regions": strings.Join(targetRegions, ","),
+		})
+	}
 
 	params := models.ScanParams{
 		ManagementGroups:       managementGroups,

--- a/internal/scanners/plugins/region/availability.go
+++ b/internal/scanners/plugins/region/availability.go
@@ -162,7 +162,7 @@ func (s *RegionSelectorScanner) fetchAllProviders(ctx context.Context, cred azco
 				if rt.Locations != nil {
 					for _, loc := range rt.Locations {
 						if loc != nil {
-							normalizedLoc := strings.ToLower(strings.ReplaceAll(*loc, " ", ""))
+							normalizedLoc := normalizeRegionName(*loc)
 							locationSet[normalizedLoc] = struct{}{}
 						}
 					}

--- a/internal/scanners/plugins/region/cost.go
+++ b/internal/scanners/plugins/region/cost.go
@@ -177,7 +177,8 @@ func (s *RegionSelectorScanner) enrichWithCostData(ctx context.Context, cred azc
 func (s *RegionSelectorScanner) getMeterCostsFromCostManagement(ctx context.Context, cred azcore.TokenCredential, subscriptionID string) ([]meterCostData, error) {
 	// Get date range: last month (like PowerShell script default)
 	now := time.Now()
-	startDate := time.Date(now.Year(), now.Month()-1, 1, 0, 0, 0, 0, time.UTC)
+	prevMonth := now.AddDate(0, -1, 0)
+	startDate := time.Date(prevMonth.Year(), prevMonth.Month(), 1, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).Add(-time.Second)
 
 	log.Debug().Msgf("Querying Cost Management for period: %s to %s", startDate.Format("2006-01-02"), endDate.Format("2006-01-02"))

--- a/internal/scanners/plugins/region/latency.go
+++ b/internal/scanners/plugins/region/latency.go
@@ -84,9 +84,9 @@ func getRegionLatency(sourceRegion, targetRegion string) float64 {
 	return 0
 }
 
-// normalizeRegionName converts region display names to lowercase identifiers matching the latency matrix
+// normalizeRegionName converts region display names to lowercase identifiers
+// by removing spaces and converting to lowercase. Use this everywhere a region
+// name needs to be compared or stored.
 func normalizeRegionName(region string) string {
-	// Remove spaces and convert to lowercase
-	normalized := strings.ToLower(strings.ReplaceAll(region, " ", ""))
-	return normalized
+	return strings.ToLower(strings.ReplaceAll(region, " ", ""))
 }

--- a/internal/scanners/plugins/region/plugin.go
+++ b/internal/scanners/plugins/region/plugin.go
@@ -60,12 +60,9 @@ func (s *RegionSelectorScanner) GetMetadata() plugins.PluginMetadata {
 	}
 }
 
-// targetRegionsFlag holds the CLI flag value at package level
-var targetRegionsFlag []string
-
 // RegisterFlags registers plugin-specific flags (implements FlagProvider interface)
 func (s *RegionSelectorScanner) RegisterFlags(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVarP(&targetRegionsFlag, "target-regions", "", []string{}, "Target regions to analyze (comma-separated, e.g., eastus,westeurope)")
+	cmd.Flags().StringSlice("target-regions", []string{}, "Target regions to analyze (comma-separated, e.g., eastus,westeurope)")
 }
 
 // init registers the plugin automatically

--- a/internal/scanners/plugins/region/selection.go
+++ b/internal/scanners/plugins/region/selection.go
@@ -43,17 +43,6 @@ func (s *RegionSelectorScanner) Scan(ctx context.Context, cred azcore.TokenCrede
 		}
 	}
 
-	// Get target regions from flag if provided
-	if len(s.targetRegions) == 0 && len(targetRegionsFlag) > 0 {
-		for _, r := range targetRegionsFlag {
-			r = normalizeRegionName(r)
-			if r != "" {
-				s.targetRegions = append(s.targetRegions, r)
-			}
-		}
-		log.Info().Msgf("Using target regions from command line: %v", s.targetRegions)
-	}
-
 	if len(s.targetRegions) == 0 {
 		s.targetRegions = []string{"swedencentral"}
 		log.Info().Msg("No target regions specified, defaulting to Sweden Central")
@@ -388,7 +377,7 @@ func (s *RegionSelectorScanner) getAllAzureRegions(ctx context.Context, subscrip
 
 // calculateScores calculates recommendation scores for each region using configurable weights
 func (s *RegionSelectorScanner) calculateScores(results []regionComparison) {
-	// Use default scoring weights (can be made configurable via CLI flags in future)
+	// Use default scoring weights
 	weights := defaultScoringWeights()
 
 	for i := range results {
@@ -607,20 +596,17 @@ func (s *RegionSelectorScanner) buildInventoryForSubscription(subscriptionID str
 		resourceType := strings.ToLower(resource.Type)
 		inventory.resourceTypes[resourceType]++
 
-		// SKU is normalized in resources graph query, including VM size, family, and capacity.
-		sku := skuInfo{
-			Name: resource.SkuName,
-		}
+		skuName := resource.SkuName
 
 		// Normalize location once; reused for both SKU and region tracking.
-		location := strings.ToLower(strings.ReplaceAll(resource.Location, " ", ""))
+		location := normalizeRegionName(resource.Location)
 
 		// Track SKUs by resource type (global)
-		if sku.Name != "" {
+		if skuName != "" {
 			if inventory.skusByType[resourceType] == nil {
 				inventory.skusByType[resourceType] = make(map[string]int)
 			}
-			inventory.skusByType[resourceType][sku.Name]++
+			inventory.skusByType[resourceType][skuName]++
 
 			// Track SKUs by type and region for detailed comparison
 			if inventory.skusByTypeAndRegion[resourceType] == nil {
@@ -629,7 +615,7 @@ func (s *RegionSelectorScanner) buildInventoryForSubscription(subscriptionID str
 			if inventory.skusByTypeAndRegion[resourceType][location] == nil {
 				inventory.skusByTypeAndRegion[resourceType][location] = make(map[string]int)
 			}
-			inventory.skusByTypeAndRegion[resourceType][location][sku.Name]++
+			inventory.skusByTypeAndRegion[resourceType][location][skuName]++
 		}
 
 		// Track locations

--- a/internal/scanners/plugins/region/types.go
+++ b/internal/scanners/plugins/region/types.go
@@ -5,12 +5,7 @@ package region
 
 import "strings"
 
-// skuInfo holds detailed SKU information for a resource
-type skuInfo struct {
-	Name     string `json:"name"`
-}
-
-// scoringWeights defines the configurable weights for the scoring algorithm
+// scoringWeights defines the weights for the scoring algorithm
 type scoringWeights struct {
 	ResourceAvailability float64 // Weight for resource type availability (default: 0.35)
 	SKUAvailability      float64 // Weight for SKU-level availability (default: 0.30)


### PR DESCRIPTION
Closes #896

## What

Analysis and cleanup of the region selection plugin based on a code review.

## Changes

### Bug fixes
- **January date bug** (`cost.go`): replace `now.Month()-1` with `now.AddDate(0,-1,0)` — idiomatic, unambiguous previous-month calculation
- **State leak between calls** (`plugin.go`, `scan.go`): removed `targetRegionsFlag` package-level global. The `--target-regions` CLI flag value is now bridged through `stageConfigs` in `scanWithPlugin`, making the CLI and MCP paths consistent (both use `ScanParams.Stages`). A second scan call with no `target-regions` no longer silently inherits regions from the previous call.

### Simplifications
- Replace 3+ inline `strings.ToLower(strings.ReplaceAll(region, " ", ""))` expressions with `normalizeRegionName()` (`selection.go`, `availability.go`, `latency.go`)
- Remove `skuInfo` single-field struct; use `string` directly (`types.go`, `selection.go`)
- Remove stale "can be made configurable via CLI flags in future" comment from `calculateScores` (`selection.go`)

## Testing

- `go test ./internal/scanners/plugins/region/...` ✅
- `go test ./internal/mcpserver/...` ✅
- `go build ./cmd/azqr/...` ✅