### PR TITLE
refactor: sql-esu plugin renamed to sql-eol

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,10 +438,10 @@ Analyzes SQL Server End-of-Life (EOL) and Extended Security Update (ESU) status 
 
 ```bash
 # Run as standalone command (fast, plugin-only mode)
-azqr sql-esu
+azqr sql-eol
 
 # Or integrate with full scan
-azqr scan --plugin sql-esu
+azqr scan --plugin sql-eol
 ```
 
 [Internal Plugins Documentation](https://azure.github.io/azqr/docs/plugins/internal-plugins/)
@@ -454,7 +454,7 @@ azqr scan --subscription-id <sub-id> \
   --plugin carbon-emissions \
   --plugin zone-mapping \
   --plugin region-selection \
-  --plugin sql-esu \
+  --plugin sql-eol \
   --output-name comprehensive-analysis
 ```
 

--- a/cmd/azqr/main.go
+++ b/cmd/azqr/main.go
@@ -10,7 +10,7 @@ import (
 	_ "github.com/Azure/azqr/internal/scanners/plugins/carbon"
 	_ "github.com/Azure/azqr/internal/scanners/plugins/openai"
 	_ "github.com/Azure/azqr/internal/scanners/plugins/region"
-	_ "github.com/Azure/azqr/internal/scanners/plugins/sqlesu"
+	_ "github.com/Azure/azqr/internal/scanners/plugins/sqleol"
 	_ "github.com/Azure/azqr/internal/scanners/plugins/zone"
 )
 

--- a/docs/content/en/docs/Plugins/internal-plugins.md
+++ b/docs/content/en/docs/Plugins/internal-plugins.md
@@ -150,9 +150,9 @@ Availability zone loss/gain applies a multiplicative adjustment to the final sco
 
 ### 5. SQL Server ESU Status
 
-**Plugin Name**: `sql-esu`  
-**Command**: `azqr sql-esu`  
-**Flag**: `--plugin sql-esu`  
+**Plugin Name**: `sql-eol`  
+**Command**: `azqr sql-eol`  
+**Flag**: `--plugin sql-eol`  
 **Version**: 0.3.0-beta
 
 Analyzes SQL Server End-of-Life (EOL) and Extended Security Update (ESU) status across Arc-enabled SQL Server instances and SQL Virtual Machines on Azure.
@@ -215,8 +215,8 @@ azqr region-selection
 # Narrow region selection to specific target regions
 azqr region-selection --target-regions=swedencentral,germanywestcentral
 
-# Run SQL ESU plugin
-azqr sql-esu
+# Run SQL EOL plugin
+azqr sql-eol
 
 # Run with specific subscriptions
 azqr zone-mapping --subscription-id <sub-id>
@@ -239,7 +239,7 @@ Run plugins alongside standard compliance scanning using the `--plugin` flag:
 azqr scan --plugin openai-throttling
 
 # Enable multiple plugins during scan
-azqr scan --plugin openai-throttling --plugin carbon-emissions --plugin zone-mapping --plugin region-selection --plugin sql-esu
+azqr scan --plugin openai-throttling --plugin carbon-emissions --plugin zone-mapping --plugin region-selection --plugin sql-eol
 
 # Combine with other scan options
 azqr scan --subscription-id <sub-id> --plugin zone-mapping --output-name analysis
@@ -265,7 +265,7 @@ openai-throttling     1.0.0      internal   Checks OpenAI/Cognitive Services acc
 carbon-emissions      1.0.0      internal   Analyzes carbon emissions by Azure resource type
 zone-mapping          1.0.0      internal   Retrieves logical-to-physical availability zone mappings...
 region-selection      0.1.0-beta internal   Scores and ranks Azure regions for workload migration...
-sql-esu               0.1.0-beta internal   Analyzes SQL Server End-of-Life and Extended Security Update status
+sql-eol               0.1.0-beta internal   Analyzes SQL Server End-of-Life and Extended Security Update status
 ```
 
 ### Plugin Details
@@ -289,7 +289,7 @@ Each internal plugin creates a dedicated worksheet in the Excel workbook:
 - **Region Selection** sheet (main scored table)
   - **Svc Avail `<region>`** sheets — one per target region with per-resource-type availability
   - **CostComparison** sheet — per-meter retail pricing across all analysed regions
-- **SQL ESU** sheet
+- **SQL EOL** sheet
 
 ```bash
 # Run plugins as standalone commands (fastest)
@@ -383,7 +383,7 @@ Internal plugins may require additional permissions beyond standard `Reader` acc
 | **zone-mapping** | Reader | Subscriptions API (locations endpoint) |
 | **openai-throttling** | Reader + Monitoring Reader | Cognitive Services, Monitor Metrics |
 | **carbon-emissions** | Reader | Carbon Optimization API |
-| **sql-esu** | Reader | Azure Resource Graph |
+| **sql-eol** | Reader | Azure Resource Graph |
 
 **Recommended**: Assign `Reader` and `Monitoring Reader` roles at subscription or management group scope.
 
@@ -394,7 +394,7 @@ Internal plugins add processing time to scans:
 - **openai-throttling**: 1-3 minutes (depends on number of OpenAI accounts)
 - **carbon-emissions**: 1-2 minutes (depends on subscription count)
 - **zone-mapping**: <10 seconds (very fast, one API call per subscription)
-- **sql-esu**: <30 seconds (single Azure Resource Graph query)
+- **sql-eol**: <30 seconds (single Azure Resource Graph query)
 
 **Optimization Tips**:
 - Enable only needed plugins

--- a/docs/content/en/docs/Usage/_index.md
+++ b/docs/content/en/docs/Usage/_index.md
@@ -265,8 +265,8 @@ azqr carbon-emissions
 # Run zone mapping analysis
 azqr zone-mapping
 
-# Run SQL ESU analysis
-azqr sql-esu
+# Run SQL EOL analysis
+azqr sql-eol
 
 # With specific subscription
 azqr zone-mapping --subscription-id <sub-id>
@@ -281,7 +281,7 @@ Run plugins alongside standard scanning:
 azqr scan --plugin openai-throttling
 
 # Multiple plugins with scan
-azqr scan --plugin openai-throttling --plugin carbon-emissions --plugin zone-mapping --plugin sql-esu
+azqr scan --plugin openai-throttling --plugin carbon-emissions --plugin zone-mapping --plugin sql-eol
 
 # With other options
 azqr scan --subscription-id <sub-id> --plugin zone-mapping

--- a/internal/mcpserver/prompt_sql_eol.go
+++ b/internal/mcpserver/prompt_sql_eol.go
@@ -14,7 +14,7 @@ func handleSQLESUPrompt() func(context.Context, mcp.GetPromptRequest) (*mcp.GetP
 		prompt := `Analyze SQL Server End-of-Life and Extended Security Update (ESU) status.
 
 Please:
-1. Use the scan-sql-esu tool to retrieve SQL Server EOL/ESU data
+1. Use the scan-sql-eol tool to retrieve SQL Server EOL/ESU data
 2. Analyze the results focusing on:
    - SQL Server instances approaching or past end-of-life
    - ESU coverage and cost implications
@@ -29,7 +29,7 @@ Please:
 		promptMessage := mcp.NewPromptMessage(mcp.RoleUser, mcp.NewTextContent(prompt))
 
 		return mcp.NewGetPromptResult(
-			"analyze SQL ESU status",
+			"analyze SQL EOL status",
 			[]mcp.PromptMessage{promptMessage},
 		), nil
 	}

--- a/internal/mcpserver/prompts.go
+++ b/internal/mcpserver/prompts.go
@@ -41,9 +41,9 @@ func RegisterPrompts(s *server.MCPServer) {
 
 	s.AddPrompt(zoneMappingPrompt, handleZoneMappingPrompt())
 
-	// SQL ESU Plugin Prompt
+	// SQL EOL Plugin Prompt
 	sqlESUPrompt := mcp.NewPrompt(
-		"analyze_sql_esu",
+		"analyze_sql_eol",
 		mcp.WithPromptDescription("Analyze SQL Server End-of-Life and Extended Security Update status with cost analysis"),
 	)
 

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -64,8 +64,8 @@ func RegisterTools(s *server.MCPServer) {
 	)
 	s.AddTool(zoneMappingTool, mcp.NewTypedToolHandler(scanPluginHandler("zone-mapping")))
 
-	// Plugin Tools: SQL ESU
-	sqlESUTool := mcp.NewTool("scan-sql-esu",
+	// Plugin Tools: SQL EOL
+	sqlEOLTool := mcp.NewTool("scan-sql-eol",
 		withBasicOptions(
 			mcp.WithDescription(
 				`Analyze SQL Server End-of-Life and Extended Security Update (ESU) status.
@@ -82,7 +82,7 @@ func RegisterTools(s *server.MCPServer) {
 				Results are saved to Excel/JSON files and returned with resource URIs for download.`),
 		)...,
 	)
-	s.AddTool(sqlESUTool, mcp.NewTypedToolHandler(scanPluginHandler("sql-esu")))
+	s.AddTool(sqlEOLTool, mcp.NewTypedToolHandler(scanPluginHandler("sql-eol")))
 
 	// Plugin Tools: Region Selection
 	regionSelectionTool := mcp.NewTool("scan-region-selection",

--- a/internal/scanners/plugins/header_consistency_test.go
+++ b/internal/scanners/plugins/header_consistency_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Azure/azqr/internal/scanners/plugins/carbon"
 	"github.com/Azure/azqr/internal/scanners/plugins/openai"
 	regionplugin "github.com/Azure/azqr/internal/scanners/plugins/region"
-	"github.com/Azure/azqr/internal/scanners/plugins/sqlesu"
+	"github.com/Azure/azqr/internal/scanners/plugins/sqleol"
 	"github.com/Azure/azqr/internal/scanners/plugins/zone"
 )
 
@@ -66,7 +66,7 @@ func TestCarbonPlugin_HeaderRow_MatchesColumnMetadata(t *testing.T) {
 }
 
 func TestSQLESUPlugin_HeaderRow_MatchesColumnMetadata(t *testing.T) {
-	assertHeaderRowMatchesColumnMetadata(t, sqlesu.NewScanner())
+	assertHeaderRowMatchesColumnMetadata(t, sqleol.NewScanner())
 }
 
 func TestRegionPlugin_HeaderRow_MatchesColumnMetadata(t *testing.T) {
@@ -81,7 +81,7 @@ func TestAllInternalPlugins_HaveColumnMetadata(t *testing.T) {
 		zone.NewScanner(),
 		openai.NewScanner(),
 		carbon.NewScanner(),
-		sqlesu.NewScanner(),
+		sqleol.NewScanner(),
 		regionplugin.NewScanner(),
 	}
 

--- a/internal/scanners/plugins/sqleol/kql/README.md
+++ b/internal/scanners/plugins/sqleol/kql/README.md
@@ -1,8 +1,8 @@
 # SQL Server ESU Scanner
 
-> **Version: 0.4.0-beta**
+> **Version: 0.5.0-beta**
 
-Scans SQL Server instances (Azure VMs and Arc-enabled) for EOL/ESU lifecycle status, estimates the full current monthly cost of staying on SQL Server IaaS, and calculates monthly savings from migrating to Azure SQL Managed Instance. The query is implemented in [sql-esu.kql](sql-esu.kql).
+Scans SQL Server instances (Azure VMs and Arc-enabled) for EOL/ESU lifecycle status, estimates the full current monthly cost of staying on SQL Server IaaS, and calculates monthly savings from migrating to Azure SQL Managed Instance. The query is implemented in [sql-eol.kql](sql-eol.kql).
 
 > **ESU is no longer free on Azure VMs.** All production editions (Standard, Enterprise, Web) are billed at full ESU rates on Azure VMs.
 
@@ -11,7 +11,7 @@ Scans SQL Server instances (Azure VMs and Arc-enabled) for EOL/ESU lifecycle sta
 1. Discovers `microsoft.sqlvirtualmachine/sqlvirtualmachines` and `microsoft.azurearcdata/sqlserverinstances` via Azure Resource Graph.
 2. Resolves vCore count by joining the underlying Azure VM SKU for IaaS instances.
 3. Assigns an `EOLStatus`: `Supported` → `Upcoming ESU` → `ESU Active` → `Expired`.
-4. Generates a `MigrationRecommendation` and auto-selects the SQL MI target tier by edition and cloud type. Arc-enabled Enterprise AHUB instances apply the **Unlimited Virtualization Benefit (UVB)** → General Purpose at `max(4, vCores÷4)` vCores. All other Enterprise → General Purpose; Standard/Web → General Purpose.
+4. Generates a `MigrationRecommendation` and estimates the SQL MI target cost using a **conservative GP-only model** (all non-UVB cases use General Purpose pricing). Arc-enabled Enterprise AHUB instances apply the **Unlimited Virtualization Benefit (UVB)** → General Purpose at `max(4, vCores÷4)` vCores. Enterprise editions without UVB receive a note that a database assessment is required before committing to a tier.
 5. Calculates current total monthly cost and estimated SQL MI cost, producing monthly savings and a migration verdict.
 
 ## Assumptions
@@ -23,10 +23,11 @@ Scans SQL Server instances (Azure VMs and Arc-enabled) for EOL/ESU lifecycle sta
 | **VM compute** | Blended PAYG by family: M-series $140, E-series $46, L-series $57, F-series $31, D/B-series $36 (per vCore/month). Windows multiplier ×1.8, West Europe ×1.13. Arc/on-prem = $0. |
 | **Patch ops** | $160/month per instance (2 hrs × $80/hr operational overhead) |
 | **SQL license cost (PAYG only)** | Enterprise: $274 · Standard: $73 · Web: $6 (per vCore/month). AHUB instances carry no hourly charge — SA is a sunk cost. |
-| **SQL MI target tier** | Arc Enterprise AHUB (on-prem) → General Purpose (UVB). Azure VM Enterprise AHUB or any Enterprise PAYG → General Purpose. Standard/Web → General Purpose. Developer/Express/Free → N/A. |
+| **SQL MI target tier** | All non-UVB cases → **General Purpose** (conservative estimate). Arc Enterprise AHUB (on-prem) → General Purpose via UVB. Enterprise editions without UVB → General Purpose with a note that a database assessment is required before committing to BC. Developer/Express/Free → N/A. |
 | **Unlimited Virtualization Benefit (UVB)** | Arc-enabled Enterprise AHUB only. 1 on-prem core with SA → up to 4 SQL MI GP vCores. Sized at `max(4, vCores ÷ 4)` × $49/vCore AHUB. Azure VMs excluded — UVB applies to on-prem workloads only. Source: [microsoft.com/licensing/faqs/1#92](https://www.microsoft.com/licensing/faqs/1#92). |
-| **SQL MI cost (PAYG)** | GP: $123/vCore/month · BC: $367/vCore/month |
-| **SQL MI cost (AHUB)** | GP: $49/vCore/month · BC: $147/vCore/month |
+| **SQL MI cost (PAYG)** | GP: $123/vCore/month |
+| **SQL MI cost (AHUB)** | GP: $49/vCore/month |
+| **SQL MI storage** | **Not included by default** (`_estimatedStorageGB = 0`). Set `_estimatedStorageGB` in `sql-eol.kql` to your environment's expected DB size to add storage to the MI cost estimate. GP rate: $0.115/GB/month (e.g. 512 GB → $58.88/month, 1,024 GB → $117.76/month). Free editions: $0. Backup storage (first 100% of provisioned size) is included free in SQL MI and is not modelled. |
 | **Consolidation ratio** | 2:1 source-to-target. Two source VMs (or Arc instances) are assumed to consolidate onto a single SQL MI, so the estimated SQL MI cost is split equally between both. This conservative ratio reflects typical PaaS consolidation; actual consolidation opportunities should be validated per workload. |
 | **Savings formula** | `Current (VM compute + SQL license if PAYG + ESU + patch ops) − Est SQL MI cost` |
 
@@ -52,11 +53,11 @@ Scans SQL Server instances (Azure VMs and Arc-enabled) for EOL/ESU lifecycle sta
 | Column | Description |
 |--------|-------------|
 | Subscription / ResourceGroup / Name / Location | Resource identity |
-| CloudType | `Azure VM (SQL IaaS)` or `Arc-enabled (On-Prem)` |
+| CloudType | `Azure VM (SQL IaaS)` · `Arc-enabled (On-Prem)` · `Arc-enabled (AWS)` · `Arc-enabled (GCP)` · `Arc-enabled (<provider>)` for any other registered cloud provider |
 | SQLVersion / Edition | Instance details |
 | EOLStatus | `Supported` · `Upcoming ESU` · `ESU Active` · `Expired` |
 | ESUStartDate / ESUEndDate | When ESU charges begin and when all support ends |
-| MigrationTargetTier | `General Purpose` · `Business Critical` · `N/A`. Arc Enterprise AHUB → `General Purpose` (UVB). All other Enterprise → `Business Critical`. |
+| MigrationTargetTier | `General Purpose` · `General Purpose (Database assessment required. Server had an Enterprise license)` · `N/A`. Arc Enterprise AHUB (on-prem) → `General Purpose` via UVB. All other non-free cases → `General Purpose` (conservative GP-only estimate). |
 | MigrationRecommendation | Actionable text guidance based on edition and EOL status |
 | vCores / BillableCores | Core count and Microsoft-minimum billable cores |
 | ESUMonthlyCostPerCore | Per-core ESU rate applied in calculations |
@@ -67,26 +68,28 @@ Scans SQL Server instances (Azure VMs and Arc-enabled) for EOL/ESU lifecycle sta
 | PatchOpsMonthlyCost | Operational overhead |
 | CurrentMonthlyCost | Total current monthly spend (all components) |
 | ConsolidationRatio | Conservative 2:1 source-to-target ratio used in MI cost allocation |
-| EstSQLMIMonthlyCost | Estimated SQL MI cost at recommended tier (2:1 consolidated).
+| EstSQLMIMonthlyCost | Estimated SQL MI cost at recommended tier (2:1 consolidated), compute + license only by default. Set `_estimatedStorageGB` in the KQL to include storage (GP rate: $0.115/GB/month). |
 | EstSQLMIMonthlySaving | Saving vs current monthly spend (negative = cost increase) |
 | SQLMIMigrationVerdict | `Cost Savings` · `Break Even` · `Cost Increase (justified by PaaS/security benefits)` |
 
 ## Limitations
 
+- SQL MI storage is **not included by default** (`_estimatedStorageGB = 0`). Set `_estimatedStorageGB` in `sql-eol.kql` to include storage in the MI cost estimate (GP rate: $0.115/GB/month). Actual storage costs depend on database size and backup retention settings.
 - Costs reflect public list pricing — EA/CSP discounts are not factored in.
 - VM compute rates are blended family-level estimates (Linux PAYG baseline), not exact billing.
 - SQL MI estimates do not account for reserved capacity pricing or workload-specific sizing.
 - UVB assumes maximum 4:1 ratio ("up to 4 vCores per on-prem core") — actual eligibility and ratio should be verified with your Microsoft licensing team.
+- Arc SQL cloud provider detection (`CloudType`) requires the underlying `microsoft.hybridcompute/machines` resource to be registered and connected. Disconnected Arc machines may show `Arc-enabled (On-Prem)` even if hosted on another cloud.
 - SQL Server inside containers or on non-Arc VMs is not discoverable via Azure Resource Graph.
 
 ## Usage
 
 ```bash
 # Plugin-only mode (fast)
-azqr sql-esu
+azqr sql-eol
 
 # As part of a full scan
-azqr scan --plugin sql-esu
+azqr scan --plugin sql-eol
 ```
 
 ## License

--- a/internal/scanners/plugins/sqleol/kql/sql-eol.kql
+++ b/internal/scanners/plugins/sqleol/kql/sql-eol.kql
@@ -12,9 +12,14 @@
 //   ESU (blended 3-year estimate: Y1=75%, Y2=100%, Y3=125% of license cost):
 //     Standard/Web:   $139/core/month  |  Enterprise: $540.50/core/month
 //     Developer/Express/Evaluation/Free: $0
-//   SQL MI target cost:
+//   SQL MI target cost (compute + license):
 //     GP  PAYG: $123/vCore/month  |  GP  AHUB: $49/vCore/month
 //     BC  PAYG: $367/vCore/month  |  BC  AHUB: $147/vCore/month
+//   SQL MI storage (default: 0 GB — storage not included by default; set _estimatedStorageGB below):
+//     GP: $0.115/GB/month  (e.g. 512 GB → $58.88 | 1,024 GB → $117.76 | 2,048 GB → $235.52)
+//     BC rate is $0.230/GB/month but not used here (recommendGeneralPurposeOnly = true)
+//     Note: first 100% of provisioned DB size in backup is included free in SQL MI — backup not modelled
+//     Free editions (Developer/Express/Evaluation/Free): $0
 //
 // MIGRATION TARGET TIER LOGIC
 //   Arc Enterprise AHUB → General Purpose via Unlimited Virtualization Benefit (UVB)
@@ -29,18 +34,27 @@ resources
 // Consolidation model: conservative 2:1 ratio — 2 source SQL Server instances per SQL MI.
 // It is conservative and likely to be higher due to right-sizing (typical SQL Server utilization is 10–30%).
 | extend consolidationRatio = 2.0
+// Assumed total storage per SQL MI target instance (GB). Set to 0 by default (storage not factored in).
+// Change to your environment's expected DB size to include storage in the MI cost estimate.
+// GP rate: $0.115/GB/month (matches recommendGeneralPurposeOnly = true below).
+// Example: 512 GB → $58.88/month | 1,024 GB → $117.76/month | 2,048 GB → $235.52/month
+| extend _estimatedStorageGB = 0
 // Force all non-UVB cases to General Purpose pricing for a conservative assessment of SQL MI cost and savings.
 | extend recommendGeneralPurposeOnly = true
+| extend _rawSQLVersion = extract(@'(?i)sql(\d{4}(?:R2)?)', 1, tostring(properties.sqlImageOffer))
 | extend SQLVersion = iff(
                           type == "microsoft.azurearcdata/sqlserverinstances",
                           tostring(properties.version),
-                          strcat("SQL Server ", replace_string(extract(@'(?i)sql(\d{4}(?:R2)?)', 1, tostring(properties.sqlImageOffer)), "2008R2", "2008 R2"))
+                          iff(isempty(_rawSQLVersion), "Unknown",
+                              strcat("SQL Server ", replace_string(_rawSQLVersion, "2008R2", "2008 R2")))
     )
 | extend Edition = iff(type == "microsoft.azurearcdata/sqlserverinstances", tostring(properties.edition), tostring(properties.sqlImageSku))
-| extend CloudType = iff(type == "microsoft.azurearcdata/sqlserverinstances", "Arc-enabled (On-Prem)", "Azure VM (SQL IaaS)")
+// CloudType is derived after the hybridcompute join below (needs _arcCloudProvider)
 // For SQL VMs, core count lives on the underlying compute VM — join to retrieve it
 | extend _vmId = iff(type == "microsoft.sqlvirtualmachine/sqlvirtualmachines", tolower(tostring(properties.virtualMachineResourceId)), "")
 | extend _sqlImageOffer = iff(type == "microsoft.sqlvirtualmachine/sqlvirtualmachines", tolower(tostring(properties.sqlImageOffer)), "")
+// For Arc SQL, containerResourceId points to the underlying hybridcompute/machines resource
+| extend _arcMachineId = iff(type == "microsoft.azurearcdata/sqlserverinstances", tolower(tostring(properties.containerResourceId)), "")
 // SQL Server license type: PAYG = paying hourly license | AHUB = bring-your-own SA license
 | extend SQLLicenseType = case(
                               type == "microsoft.azurearcdata/sqlserverinstances",
@@ -57,12 +71,33 @@ resources
     | project _vmId = tolower(id), _vmSize = tostring(properties.hardwareProfile.vmSize)
     )
     on _vmId
+// Arc SQL: join to hybridcompute/machines to get cloudMetadata.provider (AWS/GCP/empty=on-prem)
+| join kind = leftouter (
+    resources
+    | where type == "microsoft.hybridcompute/machines"
+    | project _arcMachineId = tolower(id),
+              _arcCloudProvider = tostring(properties.cloudMetadata.provider)
+    )
+    on _arcMachineId
 | join kind = leftouter (
     resourcecontainers
     | where type == 'microsoft.resources/subscriptions'
     | project SubscriptionName = name, subscriptionId
     )
     on subscriptionId
+// Derive CloudType dynamically: SQL VMs are always Azure IaaS; Arc SQL cloud origin comes from
+// hybridcompute/machines.properties.cloudMetadata.provider (empty = on-prem, "AWS", "GCP", etc.)
+| extend CloudType = case(
+                         type != "microsoft.azurearcdata/sqlserverinstances",
+                         "Azure VM (SQL IaaS)",
+                         isempty(_arcCloudProvider),
+                         "Arc-enabled (On-Prem)",
+                         strcat("Arc-enabled (", _arcCloudProvider, ")")
+    )
+// UVB (Unlimited Virtualization Benefit) is an on-premises-only licensing benefit.
+// Restrict it to Arc SQL instances with no cloud provider (genuine on-prem / Azure Local).
+| extend _isOnPremArc = type == "microsoft.azurearcdata/sqlserverinstances"
+    and isempty(_arcCloudProvider)
 // Arc SQL: properties.vCore | SQL VM: exact lookup for legacy series (SKU ≠ vCPU), regex fallback for modern v3/v4/v5/v6
 | extend vCores = case(
                       type == "microsoft.azurearcdata/sqlserverinstances",
@@ -206,6 +241,8 @@ resources
                          "Expired",
                          SQLVersion == "SQL Server 2014" and _now >= datetime(2027-07-12),
                          "Expired",
+                         // SQL 2014: ESU started 2024-07-09 (already active) — no "Upcoming ESU" window.
+                         // Goes directly Supported → ESU Active → Expired (unlike 2016/2019/2022).
                          SQLVersion == "SQL Server 2014",
                          "ESU Active",
                          SQLVersion == "SQL Server 2016" and _now >= datetime(2029-07-14),
@@ -276,7 +313,7 @@ resources
 | extend _isWebEdition = tolower(Edition) contains "web"
 | extend _recommendedMITier = case(
                                   // UVB-eligible Arc Enterprise AHUB → GP is the right tier for highly virtualized on-prem workloads
-                                  _isEnterpriseEdition and SQLLicenseType == "AHUB" and CloudType == "Arc-enabled (On-Prem)",
+                                  _isEnterpriseEdition and SQLLicenseType == "AHUB" and _isOnPremArc,
                                   "General Purpose",
                                   _isEnterpriseEdition,
                                   "General Purpose (Database assessment required. Server had an Enterprise license)",
@@ -292,7 +329,7 @@ resources
                                        EOLStatus == "Expired",
                                        "CRITICAL - Migrate now to SQL MI",
                                        EOLStatus == "ESU Active",
-                                       "Recommended - Migrate to SQL MI ",
+                                       "Recommended - Migrate to SQL MI",
                                        EOLStatus == "Upcoming ESU",
                                        "Recommended - Migrate to SQL MI",
                                        EOLStatus == "Supported",
@@ -374,7 +411,7 @@ resources
                                    _isFreeEdition,
                                    0.0,
                                    // UVB: Arc-enabled Enterprise AHUB only (already GP — UVB sizing applies regardless of useOnlyGP)
-                                   _isEnterpriseEdition and SQLLicenseType == "AHUB" and CloudType == "Arc-enabled (On-Prem)",
+                                   _isEnterpriseEdition and SQLLicenseType == "AHUB" and _isOnPremArc,
                                    49.0 * iff(vCores / 4 < 4, 4, vCores / 4),   // GP + UVB + AHUB
                                    // useOnlyGP=true: force all remaining non-UVB cases to GP pricing
                                    recommendGeneralPurposeOnly and SQLLicenseType == "AHUB",
@@ -390,17 +427,12 @@ resources
                                    49.0 * BillableCores,   // GP + AHUB (~60% off $123)
                                    123.0 * BillableCores   // GP PAYG
     )
+// Add assumed storage cost to SQL MI target (GP rate: $0.115/GB/month; free editions excluded).
+// Consolidation and savings calculations below automatically include this cost.
+| extend EstSQLMIMonthlyCost = iff(_isFreeEdition, EstSQLMIMonthlyCost,
+    EstSQLMIMonthlyCost + (_estimatedStorageGB * 0.115))
 // Savings: current total − MI target cost ($0 for free editions)
 | extend EstSQLMIMonthlySaving = iff(_isFreeEdition, 0.0, _currentMonthlyCost - EstSQLMIMonthlyCost)
-| extend SQLMIMigrationVerdict = case(
-                                     _isFreeEdition,
-                                     "N/A",
-                                     EstSQLMIMonthlySaving > 0,
-                                     "Cost Savings",
-                                     EstSQLMIMonthlySaving < 0,
-                                     "Cost Increase (justified by PaaS/security benefits)",
-                                     "Break Even"
-    )
 | extend EstSQLMIMonthlyCostConsolidated = iff(_isFreeEdition, 0.0, EstSQLMIMonthlyCost / consolidationRatio)
 | extend EstSQLMIMonthlySavingConsolidated = iff(_isFreeEdition, 0.0, _currentMonthlyCost - EstSQLMIMonthlyCostConsolidated)
 | extend SQLMIMigrationVerdictConsolidated = case(
@@ -440,7 +472,7 @@ resources
     ConsolidationRatio = tostring(consolidationRatio),
     EstSQLMIMonthlyCost = tostring(round(EstSQLMIMonthlyCostConsolidated, 2)),
     EstSQLMIMonthlySaving = tostring(round(EstSQLMIMonthlySavingConsolidated, 2)),
-    SQLMIMigrationVerdict
+    SQLMIMigrationVerdict = SQLMIMigrationVerdictConsolidated
 | order by
     case(EOLStatus == "Expired", 0, EOLStatus == "ESU Active", 1, EOLStatus == "Upcoming ESU", 2, EOLStatus == "Supported", 3, 4) asc,
     EstSQLMIMonthlySaving desc,

--- a/internal/scanners/plugins/sqleol/sqleol.go
+++ b/internal/scanners/plugins/sqleol/sqleol.go
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-package sqlesu
+package sqleol
 
 import (
 	"context"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 
 	"github.com/Azure/azqr/internal/graph"
@@ -16,13 +15,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-//go:embed kql/sql-esu.kql
-var sqlESUQuery string
+//go:embed kql/sql-eol.kql
+var sqlEOLQuery string
 
 // Scanner is an internal plugin that scans SQL Server EOL/ESU status
 type Scanner struct{}
 
-// NewScanner creates a new SQL ESU scanner
+// NewScanner creates a new SQL EOL scanner
 func NewScanner() *Scanner {
 	return &Scanner{}
 }
@@ -30,9 +29,9 @@ func NewScanner() *Scanner {
 // GetMetadata returns plugin metadata
 func (s *Scanner) GetMetadata() plugins.PluginMetadata {
 	return plugins.PluginMetadata{
-		Name:        "sql-esu",
-		Version:     "0.3.0-beta",
-		Description: "Analyzes SQL Server End-of-Life and Extended Security Update status with full cost breakdown (VM compute, SQL license, ESU), migration recommendations with target tier auto-selected by edition (Enterprise→BC, Standard/Web→GP), and unified SQL MI migration savings and verdict",
+		Name:        "sql-eol",
+		Version:     "0.5.0-beta",
+		Description: "Analyzes SQL Server End-of-Life and Extended Security Update status with full cost breakdown (VM compute, SQL license, ESU), migration recommendations with conservative GP-only SQL MI cost estimates (Enterprise editions include a note for assessment), and unified SQL MI migration savings and verdict",
 		Author:      "Azure Quick Review Team",
 		License:     "MIT",
 		Type:        plugins.PluginTypeInternal,
@@ -74,44 +73,38 @@ func (s *Scanner) Scan(ctx context.Context, cred azcore.TokenCredential, subscri
 
 	graphClient := graph.NewGraphQuery(cred)
 
-	log.Debug().Msg("Executing SQL ESU ARG query")
+	log.Debug().Msg("Executing SQL EOL ARG query")
 
-	result, err := graphClient.Query(ctx, sqlESUQuery, subscriptions)
+	result, err := graphClient.Query(ctx, sqlEOLQuery, subscriptions)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query Azure Resource Graph for SQL ESU resources: %w", err)
+		return nil, fmt.Errorf("failed to query Azure Resource Graph for SQL EOL resources: %w", err)
 	}
 
 	// Build header row from ColumnMetadata (single source of truth).
-	table := [][]string{s.GetMetadata().HeaderRow()}
+	meta := s.GetMetadata()
+	table := [][]string{meta.HeaderRow()}
 
 	if result.Data != nil {
-		for _, raw := range result.Data {
-			var r sqlESURow
-			if err := json.Unmarshal(raw, &r); err != nil {
-				log.Warn().Err(err).Msg("Skipping malformed SQL ESU row")
-				continue
-			}
-
+		for _, r := range graph.UnmarshalRows[sqlEOLRow](result.Data, "SQL EOL") {
 			if params.Filters.Azqr.IsSubscriptionExcluded(r.SubscriptionID) {
 				continue
 			}
-
 			table = append(table, r.toRecord())
 		}
 	}
 
-	log.Info().Msgf("SQL ESU scan completed with %d resources", len(table)-1)
+	log.Info().Msgf("SQL EOL scan completed with %d resources", len(table)-1)
 
 	return []plugins.ExternalPluginOutput{{
-		Metadata:    s.GetMetadata(),
-		SheetName:   "SQL ESU",
+		Metadata:    meta,
+		SheetName:   "SQL EOL",
 		Description: "SQL Server End-of-Life and Extended Security Update status with cost analysis",
 		Table:       table,
 	}}, nil
 }
 
-// sqlESURow is the shape of a single row returned by the SQL ESU ARG query.
-type sqlESURow struct {
+// sqlEOLRow is the shape of a single row returned by the SQL EOL ARG query.
+type sqlEOLRow struct {
 	SubscriptionID               string `json:"SubscriptionId"`
 	Name                         string `json:"Name"`
 	ResourceGroup                string `json:"ResourceGroup"`
@@ -142,9 +135,9 @@ type sqlESURow struct {
 	SQLMIMigrationVerdict        string `json:"SQLMIMigrationVerdict"`
 }
 
-// toRecord flattens a sqlESURow into a table row in the same column order as
+// toRecord flattens a sqlEOLRow into a table row in the same column order as
 // the plugin's ColumnMetadata.
-func (r sqlESURow) toRecord() []string {
+func (r sqlEOLRow) toRecord() []string {
 	return []string{
 		r.Subscription,
 		r.ResourceGroup,
@@ -178,5 +171,5 @@ func (r sqlESURow) toRecord() []string {
 
 // init registers the plugin automatically
 func init() {
-	plugins.RegisterInternalPlugin("sql-esu", NewScanner())
+	plugins.RegisterInternalPlugin("sql-eol", NewScanner())
 }

--- a/internal/scanners/plugins/sqleol/sqleol_test.go
+++ b/internal/scanners/plugins/sqleol/sqleol_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-package sqlesu
+package sqleol
 
 import (
 	"encoding/json"
@@ -19,8 +19,8 @@ func TestNewScanner(t *testing.T) {
 func TestScanner_GetMetadata(t *testing.T) {
 	meta := NewScanner().GetMetadata()
 
-	if meta.Name != "sql-esu" {
-		t.Errorf("Name = %q, want sql-esu", meta.Name)
+	if meta.Name != "sql-eol" {
+		t.Errorf("Name = %q, want sql-eol", meta.Name)
 	}
 	if meta.Version == "" {
 		t.Error("Version must not be empty")
@@ -28,7 +28,7 @@ func TestScanner_GetMetadata(t *testing.T) {
 	if meta.Type != plugins.PluginTypeInternal {
 		t.Errorf("Type = %v, want PluginTypeInternal", meta.Type)
 	}
-	// sql-esu exposes a wide table; guard against an accidental large drop in columns.
+	// sql-eol exposes a wide table; guard against an accidental large drop in columns.
 	if len(meta.ColumnMetadata) < 20 {
 		t.Errorf("ColumnMetadata len = %d, want >= 20", len(meta.ColumnMetadata))
 	}
@@ -46,7 +46,7 @@ func TestScanner_GetMetadata(t *testing.T) {
 }
 
 // TestSQLESURow_Unmarshal verifies the JSON tag mapping from the ARG query
-// result into sqlESURow, including the lower-cased "vCores" tag.
+// result into sqlEOLRow, including the lower-cased "vCores" tag.
 func TestSQLESURow_Unmarshal(t *testing.T) {
 	raw := []byte(`{
 		"SubscriptionId": "sub-123",
@@ -59,7 +59,7 @@ func TestSQLESURow_Unmarshal(t *testing.T) {
 		"ConsolidationRatio": "2"
 	}`)
 
-	var r sqlESURow
+	var r sqlEOLRow
 	if err := json.Unmarshal(raw, &r); err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestSQLESURow_Unmarshal(t *testing.T) {
 // TestSQLESURow_ToRecord verifies the flattened record preserves field order and
 // has one entry per declared column.
 func TestSQLESURow_ToRecord(t *testing.T) {
-	r := sqlESURow{
+	r := sqlEOLRow{
 		Name:                  "sql-vm-1",
 		ResourceGroup:         "rg-sql",
 		Subscription:          "Prod",


### PR DESCRIPTION
# Description

This pull request renames the internal SQL Server plugin from `sql-esu` to `sql-eol` throughout the codebase and documentation to better reflect its focus on End-of-Life (EOL) and Extended Security Update (ESU) analysis. It also updates the KQL cost estimation model for SQL Managed Instance migration to use a more conservative General Purpose-only approach, clarifies storage cost handling, and improves documentation for migration recommendations and limitations.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
