### PR TITLE
feat: add findings summary stage to scan pipeline

### DIFF
--- a/cmd/azqr/commands/alternative_vm_sku.go
+++ b/cmd/azqr/commands/alternative_vm_sku.go
@@ -37,6 +37,7 @@ The compatibility score (0.0–1.0) is computed from:
   - Accelerated networking     (weight 0.05)
 
 Returns the top N results (default 10) as JSON.`,
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		skuName, _ := cmd.Flags().GetString("sku")
 		top, _ := cmd.Flags().GetInt("top")

--- a/cmd/azqr/commands/compare.go
+++ b/cmd/azqr/commands/compare.go
@@ -32,7 +32,8 @@ Supports Excel (.xlsx).
 For Excel format, the comparison provides:
   - Row count comparison for each sheet
   - Detection of duplicate rows after row 4 (data rows)`,
-	Args: cobra.NoArgs,
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		file1, _ := cmd.Flags().GetString("file1")

--- a/cmd/azqr/commands/mcpserver.go
+++ b/cmd/azqr/commands/mcpserver.go
@@ -33,7 +33,8 @@ Examples:
   
   # Start in HTTP/SSE mode on custom port
   azqr mcp --mode http --addr :3000`,
-	Args: cobra.NoArgs,
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		mode := mcpserver.ServerMode(mcpMode)
 		mcpserver.StartWithMode(mode, mcpAddr, version)

--- a/cmd/azqr/commands/plugins.go
+++ b/cmd/azqr/commands/plugins.go
@@ -26,10 +26,11 @@ var pluginsCmd = &cobra.Command{
 }
 
 var pluginsListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all registered plugins",
-	Long:  "List all registered plugins including built-in and external command plugins",
-	Args:  cobra.NoArgs,
+	Use:          "list",
+	Short:        "List all registered plugins",
+	Long:         "List all registered plugins including built-in and external command plugins",
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		registry := plugins.GetRegistry()
 		pluginList := registry.List()
@@ -64,10 +65,11 @@ var pluginsListCmd = &cobra.Command{
 }
 
 var pluginsInfoCmd = &cobra.Command{
-	Use:   "info <plugin-name>",
-	Short: "Show detailed information about a plugin",
-	Long:  "Show detailed information about a specific plugin including metadata and capabilities",
-	Args:  cobra.ExactArgs(1),
+	Use:          "info <plugin-name>",
+	Short:        "Show detailed information about a plugin",
+	Long:         "Show detailed information about a specific plugin including metadata and capabilities",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		pluginName := args[0]
 		registry := plugins.GetRegistry()

--- a/cmd/azqr/commands/root.go
+++ b/cmd/azqr/commands/root.go
@@ -20,11 +20,12 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:     "azqr",
-	Short:   "Azure Quick Review (azqr) goal is to produce a high level assessment of an Azure Subscription or Resource Group",
-	Long:    `Azure Quick Review (azqr) goal is to produce a high level assessment of an Azure Subscription or Resource Group`,
-	Args:    cobra.NoArgs,
-	Version: version,
+	Use:          "azqr",
+	Short:        "Azure Quick Review (azqr) goal is to produce a high level assessment of an Azure Subscription or Resource Group",
+	Long:         `Azure Quick Review (azqr) goal is to produce a high level assessment of an Azure Subscription or Resource Group`,
+	Args:         cobra.NoArgs,
+	Version:      version,
+	SilenceUsage: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Initialize log level based on --debug flag
 		// This runs before any command executes, making debug logging available globally
@@ -75,16 +76,19 @@ func Execute() {
 			// Capture pluginName in closure properly
 			pName := pluginName
 			// Set the Run function to enable only this plugin
-			plugin.Command.Run = func(cmd *cobra.Command, args []string) {
+			plugin.Command.Run = nil
+			plugin.Command.RunE = func(cmd *cobra.Command, args []string) error {
 				// Enable only this specific plugin
 				// Note: We can't use Set() for StringArray flags, so we pass it directly to scan
 				scannerKeys, _ := models.GetScanners()
 				// Create a custom scan with this plugin enabled
-				scanWithPlugin(cmd, scannerKeys, pName)
+				return scanWithPlugin(cmd, scannerKeys, pName)
 			}
 			rootCmd.AddCommand(plugin.Command)
 		}
 	}
 
-	cobra.CheckErr(rootCmd.Execute())
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/cmd/azqr/commands/rules.go
+++ b/cmd/azqr/commands/rules.go
@@ -16,10 +16,11 @@ func init() {
 }
 
 var rulesCmd = &cobra.Command{
-	Use:   "rules",
-	Short: "Print all recommendations",
-	Long:  "Print all recommendations as markdown table",
-	Args:  cobra.NoArgs,
+	Use:          "rules",
+	Short:        "Print all recommendations",
+	Long:         "Print all recommendations as markdown table",
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		oj, _ := cmd.Flags().GetBool("json")
 		output := renderers.GetAllRecommendations(!oj)

--- a/cmd/azqr/commands/scan.go
+++ b/cmd/azqr/commands/scan.go
@@ -4,13 +4,13 @@
 package commands
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Azure/azqr/internal/models"
 	"github.com/Azure/azqr/internal/pipeline"
 	"github.com/Azure/azqr/internal/profiling"
 
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -41,17 +41,18 @@ func init() {
 }
 
 var scanCmd = &cobra.Command{
-	Use:   "scan",
-	Short: "Scan Azure Resources",
-	Long:  "Scan Azure Resources",
-	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:          "scan",
+	Short:        "Scan Azure Resources",
+	Long:         "Scan Azure Resources",
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		scannerKeys, _ := models.GetScanners()
-		scan(cmd, scannerKeys)
+		return scan(cmd, scannerKeys)
 	},
 }
 
-func scan(cmd *cobra.Command, scannerKeys []string) {
+func scan(cmd *cobra.Command, scannerKeys []string) error {
 	managementGroups, _ := cmd.Flags().GetStringSlice("management-group-id")
 	subscriptions, _ := cmd.Flags().GetStringSlice("subscription-id")
 	resourceGroups, _ := cmd.Flags().GetStringSlice("resource-group")
@@ -88,7 +89,7 @@ func scan(cmd *cobra.Command, scannerKeys []string) {
 	stageConfigs.ConfigureStages(stageNames)
 
 	if err := stageConfigs.ApplyStageParams(stageParams); err != nil {
-		log.Fatal().Err(err).Msg("failed applying stage parameters")
+		return fmt.Errorf("failed applying stage parameters: %w", err)
 	}
 
 	params := models.ScanParams{
@@ -111,12 +112,13 @@ func scan(cmd *cobra.Command, scannerKeys []string) {
 	}
 
 	scanner := pipeline.Scanner{}
-	scanner.Scan(&params)
+	_, err := scanner.Scan(&params)
+	return err
 }
 
 // scanWithPlugin is a specialized version of scan that enables a specific plugin
 // and forces plugin-only mode for faster execution by calling ScanPlugins directly
-func scanWithPlugin(cmd *cobra.Command, scannerKeys []string, pluginName string) {
+func scanWithPlugin(cmd *cobra.Command, scannerKeys []string, pluginName string) error {
 	managementGroups, _ := cmd.Flags().GetStringSlice("management-group-id")
 	subscriptions, _ := cmd.Flags().GetStringSlice("subscription-id")
 	resourceGroups, _ := cmd.Flags().GetStringSlice("resource-group")
@@ -177,5 +179,6 @@ func scanWithPlugin(cmd *cobra.Command, scannerKeys []string, pluginName string)
 
 	scanner := pipeline.Scanner{}
 	// Call ScanPlugins directly for optimized plugin-only execution
-	scanner.ScanPlugins(&params)
+	_, err := scanner.ScanPlugins(&params)
+	return err
 }

--- a/cmd/azqr/commands/scanners.go
+++ b/cmd/azqr/commands/scanners.go
@@ -33,14 +33,15 @@ func init() {
 
 		// Create command for this scanner
 		cmd := &cobra.Command{
-			Use:   abbr,
-			Short: fmt.Sprintf("Scan %s", serviceName),
-			Long:  fmt.Sprintf("Scan %s", serviceName),
-			Args:  cobra.NoArgs,
-			Run: func(cmd *cobra.Command, args []string) {
+			Use:          abbr,
+			Short:        fmt.Sprintf("Scan %s", serviceName),
+			Long:         fmt.Sprintf("Scan %s", serviceName),
+			Args:         cobra.NoArgs,
+			SilenceUsage: true,
+			RunE: func(cmd *cobra.Command, args []string) error {
 				// Capture the abbreviation in the closure
 				scannerAbbr := abbr
-				scan(cmd, []string{scannerAbbr})
+				return scan(cmd, []string{scannerAbbr})
 			},
 		}
 

--- a/internal/findings/summary.go
+++ b/internal/findings/summary.go
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package findings provides the canonical summary of azqr recommendations.
+package findings
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Azure/azqr/internal/models"
+)
+
+// Recommendation is the normalized summary of one recommendation.
+type Recommendation struct {
+	ID                string `json:"id"`
+	Recommendation    string `json:"recommendation"`
+	Source            string `json:"source"`
+	Category          string `json:"category"`
+	Impact            string `json:"impact"`
+	ResourceType      string `json:"resourceType"`
+	LongDescription   string `json:"longDescription,omitempty"`
+	LearnURL          string `json:"learnUrl,omitempty"`
+	ImpactedResources int    `json:"impactedResources"`
+}
+
+// Summary contains deterministic recommendation and finding aggregates.
+type Summary struct {
+	Recommendations      []Recommendation `json:"recommendations"`
+	Resources            int              `json:"resources"`
+	ImpactedResources    int              `json:"impactedResources"`
+	ImpactedByImpact     map[string]int   `json:"impactedByImpact"`
+	ImpactedByCategory   map[string]int   `json:"impactedByCategory"`
+	RecommendationsFound int              `json:"recommendationsFound"`
+}
+
+type findingKey struct {
+	recommendationID string
+	resourceID       string
+}
+
+// Build creates a canonical summary from recommendation definitions and graph results.
+func Build(
+	definitions map[string]map[string]*models.GraphRecommendation,
+	results []*models.GraphResult,
+	resourceCount int,
+) *Summary {
+	records := make(map[string]Recommendation)
+
+	for _, byID := range definitions {
+		for _, definition := range byID {
+			if definition == nil || strings.EqualFold(definition.Category, string(models.CategorySLA)) {
+				continue
+			}
+			records[normalize(definition.RecommendationID)] = recommendationFromDefinition(definition)
+		}
+	}
+
+	counts := make(map[string]int)
+	seen := make(map[findingKey]struct{}, len(results))
+	for _, result := range results {
+		if result == nil || strings.EqualFold(string(result.Category), string(models.CategorySLA)) {
+			continue
+		}
+
+		id := normalize(result.RecommendationID)
+		if id == "" {
+			continue
+		}
+		if _, ok := records[id]; !ok {
+			continue
+		}
+
+		key := findingKey{
+			recommendationID: id,
+			resourceID:       normalize(result.ResourceID),
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		counts[id]++
+	}
+
+	recommendations := make([]Recommendation, 0, len(records))
+	summary := &Summary{
+		Resources:          resourceCount,
+		ImpactedByImpact:   make(map[string]int),
+		ImpactedByCategory: make(map[string]int),
+	}
+	for id, record := range records {
+		record.ImpactedResources = counts[id]
+		recommendations = append(recommendations, record)
+		if record.ImpactedResources == 0 {
+			continue
+		}
+		summary.RecommendationsFound++
+		summary.ImpactedResources += record.ImpactedResources
+		summary.ImpactedByImpact[record.Impact] += record.ImpactedResources
+		summary.ImpactedByCategory[record.Category] += record.ImpactedResources
+	}
+
+	sort.Slice(recommendations, func(i, j int) bool {
+		if recommendations[i].ResourceType != recommendations[j].ResourceType {
+			return recommendations[i].ResourceType < recommendations[j].ResourceType
+		}
+		return recommendations[i].ID < recommendations[j].ID
+	})
+	summary.Recommendations = recommendations
+	return summary
+}
+
+func recommendationFromDefinition(definition *models.GraphRecommendation) Recommendation {
+	learnURL := ""
+	if len(definition.LearnMoreLink) > 0 {
+		learnURL = definition.LearnMoreLink[0].Url
+	}
+	return Recommendation{
+		ID:              definition.RecommendationID,
+		Recommendation:  definition.Recommendation,
+		Source:          definition.Source,
+		Category:        definition.Category,
+		Impact:          definition.Impact,
+		ResourceType:    definition.ResourceType,
+		LongDescription: definition.LongDescription,
+		LearnURL:        learnURL,
+	}
+}
+
+func normalize(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/internal/findings/summary_test.go
+++ b/internal/findings/summary_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package findings
+
+import (
+	"testing"
+
+	"github.com/Azure/azqr/internal/models"
+)
+
+func TestBuildDeduplicatesAndSkipsSLA(t *testing.T) {
+	definitions := map[string]map[string]*models.GraphRecommendation{
+		"microsoft.test/widgets": {
+			"rec-1": {
+				RecommendationID: "rec-1",
+				Recommendation:   "Fix widget",
+				Category:         string(models.CategorySecurity),
+				Impact:           string(models.ImpactHigh),
+				ResourceType:     "Microsoft.Test/widgets",
+			},
+			"sla": {
+				RecommendationID: "sla",
+				Category:         string(models.CategorySLA),
+				Impact:           string(models.ImpactLow),
+			},
+		},
+	}
+	results := []*models.GraphResult{
+		{RecommendationID: "rec-1", ResourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Test/widgets/one", Category: models.CategorySecurity, Impact: models.ImpactHigh},
+		{RecommendationID: "REC-1", ResourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Test/widgets/ONE", Category: models.CategorySecurity, Impact: models.ImpactHigh},
+		{RecommendationID: "sla", ResourceID: "resource", Category: models.CategorySLA, Impact: models.ImpactLow},
+	}
+
+	summary := Build(definitions, results, 4)
+
+	if len(summary.Recommendations) != 1 {
+		t.Fatalf("got %d recommendations, want 1", len(summary.Recommendations))
+	}
+	if summary.Recommendations[0].ImpactedResources != 1 {
+		t.Fatalf("got %d impacted resources, want 1", summary.Recommendations[0].ImpactedResources)
+	}
+	if summary.Resources != 4 || summary.ImpactedResources != 1 || summary.RecommendationsFound != 1 {
+		t.Fatalf("unexpected summary totals: %+v", summary)
+	}
+	if summary.ImpactedByImpact[string(models.ImpactHigh)] != 1 {
+		t.Fatalf("unexpected impact totals: %+v", summary.ImpactedByImpact)
+	}
+}
+
+func TestBuildIgnoresResultWithoutDefinition(t *testing.T) {
+	summary := Build(nil, []*models.GraphResult{{
+		RecommendationID: "external",
+		Recommendation:   "External recommendation",
+		ResourceID:       "resource",
+		ResourceType:     "Microsoft.Test/widgets",
+		Category:         models.CategoryGovernance,
+		Impact:           models.ImpactMedium,
+	}}, 1)
+
+	if len(summary.Recommendations) != 0 || summary.ImpactedResources != 0 {
+		t.Fatalf("unexpected summary for undefined recommendation: %+v", summary)
+	}
+}

--- a/internal/mcpserver/tool_plugin.go
+++ b/internal/mcpserver/tool_plugin.go
@@ -42,7 +42,10 @@ func scanPluginHandler(pluginName string) func(context.Context, mcp.CallToolRequ
 		}
 
 		scanner := pipeline.Scanner{}
-		r := scanner.ScanPlugins(params)
+		r, err := scanner.ScanPlugins(params)
+		if err != nil {
+			return nil, err
+		}
 
 		fileName := params.OutputName + ".xlsx"
 		uri := fmt.Sprintf("file://%s", fileName)

--- a/internal/mcpserver/tool_scan.go
+++ b/internal/mcpserver/tool_scan.go
@@ -28,7 +28,10 @@ func scanHandler(ctx context.Context, request mcp.CallToolRequest, args models.S
 	params.OutputName = currentDir + "/azqr_scan_results"
 
 	scanner := pipeline.Scanner{}
-	r := scanner.Scan(params)
+	r, err := scanner.Scan(params)
+	if err != nil {
+		return nil, err
+	}
 
 	fileName := params.OutputName + ".xlsx"
 	uri := fmt.Sprintf("file://%s", fileName)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -179,6 +180,21 @@ const (
 	CategoryServiceUpgradeAndRetirement RecommendationCategory = "ServiceUpgradeAndRetirement"
 	CategorySLA                         RecommendationCategory = "SLA"
 )
+
+// SeverityRank returns a numeric ordering rank for a recommendation impact level.
+// High=3, Medium=2, Low=1. Returns (0, false) for unknown values.
+func SeverityRank(impact string) (int, bool) {
+	switch {
+	case strings.EqualFold(impact, string(ImpactHigh)):
+		return 3, true
+	case strings.EqualFold(impact, string(ImpactMedium)):
+		return 2, true
+	case strings.EqualFold(impact, string(ImpactLow)):
+		return 1, true
+	default:
+		return 0, false
+	}
+}
 
 func LogSubscriptionScan(subscriptionID string, source string) {
 	log.Info().

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -202,3 +202,15 @@ func TestRecommendationConstants(t *testing.T) {
 		}
 	}
 }
+
+func TestSeverityRank(t *testing.T) {
+	for impact, want := range map[string]int{"high": 3, "Medium": 2, "LOW": 1} {
+		got, ok := SeverityRank(impact)
+		if !ok || got != want {
+			t.Errorf("SeverityRank(%q) = %d, %v; want %d, true", impact, got, ok, want)
+		}
+	}
+	if _, ok := SeverityRank("critical"); ok {
+		t.Error("unknown severity should be rejected")
+	}
+}

--- a/internal/pipeline/builder.go
+++ b/internal/pipeline/builder.go
@@ -51,6 +51,7 @@ func (b *ScanPipelineBuilder) BuildDefault() *Pipeline {
 		With(NewArcSQLStage()).
 		With(NewCostStage()).
 		With(NewPluginExecutionStage()).
+		With(NewFindingsSummaryStage()).
 		With(NewReportRenderingStage()).
 		With(NewProfilingCleanupStage()).
 		Build()
@@ -63,6 +64,7 @@ func (b *ScanPipelineBuilder) BuildPluginOnly() *Pipeline {
 		With(NewInitializationStage()).
 		With(NewSubscriptionDiscoveryStage()).
 		With(NewPluginExecutionStage()).
+		With(NewFindingsSummaryStage()).
 		With(NewReportRenderingStage()).
 		With(NewProfilingCleanupStage()).
 		Build()

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -214,12 +214,13 @@ func TestPipeline_Integration(t *testing.T) {
 		NewAzurePolicyStage(),
 		NewArcSQLStage(),
 		NewCostStage(),
+		NewFindingsSummaryStage(),
 		NewReportRenderingStage(),
 	)
 
 	// Just verify pipeline structure is valid
-	if len(pipeline.stages) != 12 {
-		t.Errorf("Expected 12 stages, got %d", len(pipeline.stages))
+	if len(pipeline.stages) != 13 {
+		t.Errorf("Expected 13 stages, got %d", len(pipeline.stages))
 	}
 
 	t.Logf("Pipeline created with %d stages", len(pipeline.stages))

--- a/internal/pipeline/scanner.go
+++ b/internal/pipeline/scanner.go
@@ -4,6 +4,7 @@
 package pipeline
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/Azure/azqr/internal/models"
@@ -14,18 +15,17 @@ import (
 type Scanner struct{}
 
 // Scan performs a full scan using the default pipeline
-func (sc *Scanner) Scan(params *models.ScanParams) *renderers.ReportData {
+func (sc *Scanner) Scan(params *models.ScanParams) (*renderers.ReportData, error) {
 	return sc.scan(params, true)
 }
 
 // ScanPlugins performs a scan using only the plugin execution stage
-func (sc *Scanner) ScanPlugins(params *models.ScanParams) *renderers.ReportData {
+func (sc *Scanner) ScanPlugins(params *models.ScanParams) (*renderers.ReportData, error) {
 	return sc.scan(params, false)
 }
 
 // scan executes the scan using the composable pipeline pattern
-func (sc *Scanner) scan(params *models.ScanParams, defaultPipeline bool) *renderers.ReportData {
-	// Import pipeline package
+func (sc *Scanner) scan(params *models.ScanParams, defaultPipeline bool) (*renderers.ReportData, error) {
 	builder := NewScanPipelineBuilder()
 
 	// Create scan context
@@ -35,7 +35,7 @@ func (sc *Scanner) scan(params *models.ScanParams, defaultPipeline bool) *render
 	if defaultPipeline {
 		// Ensure graph stage is enabled for regular scans
 		if err := params.Stages.ValidateGraphStageEnabled(); err != nil {
-			log.Fatal().Err(err).Msg("Configuration error")
+			return nil, fmt.Errorf("invalid scan configuration: %w", err)
 		}
 		pipe = builder.BuildDefault()
 	} else {
@@ -44,7 +44,7 @@ func (sc *Scanner) scan(params *models.ScanParams, defaultPipeline bool) *render
 
 	err := pipe.Execute(scanCtx)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Scan failed")
+		return nil, fmt.Errorf("scan failed: %w", err)
 	}
 
 	// Log metrics in debug mode
@@ -59,5 +59,5 @@ func (sc *Scanner) scan(params *models.ScanParams, defaultPipeline bool) *render
 	seconds := int(elapsedTime.Seconds()) % 60
 	log.Info().Msgf("Scan completed in %02d:%02d:%02d", hours, minutes, seconds)
 
-	return scanCtx.ReportData
+	return scanCtx.ReportData, nil
 }

--- a/internal/pipeline/simple_stage_test.go
+++ b/internal/pipeline/simple_stage_test.go
@@ -270,6 +270,7 @@ func TestBuildDefault_StageCountAndOrder(t *testing.T) {
 		"Arc-enabled SQL Server Scan",
 		"Cost Analysis Scan",
 		"Plugin Execution",
+		"Findings Summary",
 		"Report Rendering",
 		"Profiling Cleanup",
 	}
@@ -293,6 +294,7 @@ func TestBuildPluginOnly_StageCountAndOrder(t *testing.T) {
 		"Initialization",
 		"Subscription Discovery",
 		"Plugin Execution",
+		"Findings Summary",
 		"Report Rendering",
 		"Profiling Cleanup",
 	}

--- a/internal/pipeline/stage_findings_summary.go
+++ b/internal/pipeline/stage_findings_summary.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package pipeline
+
+import "github.com/Azure/azqr/internal/findings"
+
+// FindingsSummaryStage builds the canonical recommendation summary.
+type FindingsSummaryStage struct {
+	*BaseStage
+}
+
+// NewFindingsSummaryStage creates a findings summary stage.
+func NewFindingsSummaryStage() *FindingsSummaryStage {
+	return &FindingsSummaryStage{BaseStage: NewBaseStage("Findings Summary", true)}
+}
+
+// Execute builds the summary after all recommendation-producing stages finish.
+func (s *FindingsSummaryStage) Execute(ctx *ScanContext) error {
+	ctx.ReportData.Summary = findings.Build(
+		ctx.ReportData.Recommendations,
+		ctx.ReportData.Graph,
+		len(ctx.ReportData.Resources),
+	)
+	return nil
+}

--- a/internal/pipeline/stage_initialization.go
+++ b/internal/pipeline/stage_initialization.go
@@ -34,7 +34,9 @@ func (s *InitializationStage) Execute(ctx *ScanContext) error {
 	ctx.Params.OutputName = outputFile
 
 	// Step 3: Validate and prepare filters
-	s.validateAndPrepareFilters(ctx.Params)
+	if err := s.validateAndPrepareFilters(ctx.Params); err != nil {
+		return err
+	}
 
 	// Step 4: Create Azure credentials
 	ctx.Cred = az.NewAzureCredential()
@@ -96,7 +98,7 @@ func (s *InitializationStage) generateOutputFileName(outputName string) string {
 }
 
 // validateAndPrepareFilters validates input parameters and prepares filters
-func (s *InitializationStage) validateAndPrepareFilters(params *models.ScanParams) {
+func (s *InitializationStage) validateAndPrepareFilters(params *models.ScanParams) error {
 	filters := params.Filters
 
 	log.Debug().
@@ -105,15 +107,15 @@ func (s *InitializationStage) validateAndPrepareFilters(params *models.ScanParam
 
 	// validate input
 	if len(params.ManagementGroups) > 0 && (len(params.Subscriptions) > 0 || len(params.ResourceGroups) > 0) {
-		log.Fatal().Msg("Management Group name cannot be used with a Subscription Id or Resource Group name")
+		return fmt.Errorf("management group name cannot be used with a subscription ID or resource group name")
 	}
 
 	if len(params.Subscriptions) < 1 && len(params.ResourceGroups) > 0 {
-		log.Fatal().Msg("Resource Group name can only be used with a Subscription Id")
+		return fmt.Errorf("resource group name can only be used with a subscription ID")
 	}
 
 	if len(params.Subscriptions) > 1 && len(params.ResourceGroups) > 0 {
-		log.Fatal().Msg("Resource Group name can only be used with 1 Subscription Id")
+		return fmt.Errorf("resource group name can only be used with one subscription ID")
 	}
 
 	if len(params.Subscriptions) > 0 {
@@ -131,4 +133,5 @@ func (s *InitializationStage) validateAndPrepareFilters(params *models.ScanParam
 	log.Debug().
 		Int("scanners_after", len(filters.Azqr.Scanners)).
 		Msg("Filters validation completed")
+	return nil
 }

--- a/internal/renderers/report_data.go
+++ b/internal/renderers/report_data.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Azure/azqr/internal/findings"
 	"github.com/Azure/azqr/internal/models"
 	"github.com/Azure/azqr/internal/skus"
 )
@@ -28,6 +29,8 @@ type (
 		ResourceTypeCount       []*models.ResourceTypeCount                       `json:"resourceTypeCount,omitempty"`
 		PluginResults           []*PluginResult                                   `json:"pluginResults,omitempty"`
 		Stages                  *models.StageConfigs                              `json:"-"`
+		Summary                 *findings.Summary                                 `json:"-"`
+		ScopeID                 string                                            `json:"-"`
 
 		// Table caches - populated on first call, reused thereafter
 		cachedImpactedTable                [][]string `json:"-"`
@@ -299,15 +302,10 @@ func (rd *ReportData) RecommendationsTable() [][]string {
 		return rd.cachedRecommendationsTable
 	}
 
-	counter := map[string]int{}
-	for _, rt := range rd.Recommendations {
-		for _, r := range rt {
-			counter[r.RecommendationID] = 0
-		}
-	}
-
-	for _, r := range rd.Graph {
-		counter[r.RecommendationID]++
+	if rd.Summary == nil {
+		// Fallback for callers that build ReportData outside the pipeline (e.g. tests).
+		// FindingsSummaryStage populates this during normal scans.
+		rd.Summary = findings.Build(rd.Recommendations, rd.Graph, len(rd.Resources))
 	}
 
 	headers := []string{"Implemented", "Number of Impacted Resources", "Azure Service / Well-Architected", "Recommendation Source",
@@ -315,7 +313,7 @@ func (rd *ReportData) RecommendationsTable() [][]string {
 		"Impact", "Best Practices Guidance", "Read More", "Recommendation Id"}
 
 	// Estimate capacity based on recommendations count
-	estimatedCap := len(counter) + 1
+	estimatedCap := len(rd.Summary.Recommendations) + 1
 	rows := make([][]string, 1, estimatedCap)
 	rows[0] = headers
 
@@ -326,54 +324,39 @@ func (rd *ReportData) RecommendationsTable() [][]string {
 	// Always consider Microsoft.Resources as deployed
 	deployedTypes["microsoft.resources"] = true
 
-	// Outer key is already lowercase (set by ListRecommendations).
-	// Hoist the deployedTypes check to the outer loop — one lookup per resource
-	// type instead of one per recommendation, and zero ToLower allocations.
-	for lowerType, rt := range rd.Recommendations {
-		typeIsDeployed := deployedTypes[lowerType]
-		for _, r := range rt {
-			if skipCategory(r.Category) {
-				continue
-			}
-
-			var implemented string
-			switch {
-			case !typeIsDeployed:
-				implemented = "N/A"
-			case counter[r.RecommendationID] == 0:
-				implemented = "true"
-			default:
-				implemented = "false"
-			}
-
-			categoryPart := ""
-			servicePart := ""
-			typeParts := strings.Split(r.ResourceType, "/")
-			categoryPart = typeParts[0]
-			if len(typeParts) > 1 {
-				servicePart = typeParts[1]
-			}
-
-			// Cache string conversions
-			category := string(r.Category)
-			impact := string(r.Impact)
-
-			row := []string{
-				implemented,
-				fmt.Sprint(counter[r.RecommendationID]),
-				"Azure Service",
-				r.Source,
-				categoryPart,
-				servicePart,
-				category,
-				r.Recommendation,
-				impact,
-				r.LongDescription,
-				r.LearnMoreLink[0].Url,
-				r.RecommendationID,
-			}
-			rows = append(rows, row)
+	for _, r := range rd.Summary.Recommendations {
+		typeIsDeployed := deployedTypes[strings.ToLower(r.ResourceType)]
+		var implemented string
+		switch {
+		case !typeIsDeployed:
+			implemented = "N/A"
+		case r.ImpactedResources == 0:
+			implemented = "true"
+		default:
+			implemented = "false"
 		}
+
+		typeParts := strings.Split(r.ResourceType, "/")
+		categoryPart := typeParts[0]
+		servicePart := ""
+		if len(typeParts) > 1 {
+			servicePart = typeParts[1]
+		}
+
+		rows = append(rows, []string{
+			implemented,
+			fmt.Sprint(r.ImpactedResources),
+			"Azure Service",
+			r.Source,
+			categoryPart,
+			servicePart,
+			r.Category,
+			r.Recommendation,
+			r.Impact,
+			r.LongDescription,
+			r.LearnURL,
+			r.ID,
+		})
 	}
 
 	rd.cachedRecommendationsTable = rows
@@ -509,7 +492,7 @@ func (rd *ReportData) resourcesTable(resources []*models.Resource) [][]string {
 
 	slaMap := make(map[string]string, len(rd.Graph))
 	for _, a := range rd.Graph {
-		if a.Category == models.CategorySLA {
+		if strings.EqualFold(string(a.Category), string(models.CategorySLA)) {
 			slaMap[strings.ToLower(a.ResourceID)] = a.Param1
 		}
 	}
@@ -549,5 +532,5 @@ func (rd *ReportData) resourcesTable(resources []*models.Resource) [][]string {
 }
 
 func skipCategory(category string) bool {
-	return category == string(models.CategorySLA)
+	return strings.EqualFold(category, string(models.CategorySLA))
 }

--- a/internal/renderers/report_data_test.go
+++ b/internal/renderers/report_data_test.go
@@ -4,11 +4,139 @@
 package renderers
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/Azure/azqr/internal/models"
 )
+
+func TestRecommendationsTablePreservesReportContract(t *testing.T) {
+	impacted := graphRecommendation(
+		"rec-impacted",
+		"Microsoft.Test/widgets",
+		"Fix impacted widget",
+		string(models.CategorySecurity),
+		string(models.ImpactHigh),
+	)
+	clean := graphRecommendation(
+		"rec-clean",
+		"Microsoft.Test/widgets",
+		"Keep widget clean",
+		string(models.CategoryGovernance),
+		string(models.ImpactMedium),
+	)
+	notDeployed := graphRecommendation(
+		"rec-not-deployed",
+		"Microsoft.Other/things",
+		"Configure other thing",
+		string(models.CategoryHighAvailability),
+		string(models.ImpactLow),
+	)
+	sla := graphRecommendation(
+		"rec-sla",
+		"Microsoft.Test/widgets",
+		"Check SLA",
+		string(models.CategorySLA),
+		string(models.ImpactLow),
+	)
+
+	data := &ReportData{
+		Recommendations: map[string]map[string]*models.GraphRecommendation{
+			"microsoft.test/widgets": {
+				impacted.RecommendationID: impacted,
+				clean.RecommendationID:    clean,
+				sla.RecommendationID:      sla,
+			},
+			"microsoft.other/things": {
+				notDeployed.RecommendationID: notDeployed,
+			},
+		},
+		Graph: []*models.GraphResult{
+			{
+				RecommendationID: impacted.RecommendationID,
+				ResourceID:       "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Test/widgets/one",
+				Category:         models.CategorySecurity,
+				Impact:           models.ImpactHigh,
+			},
+			// Duplicate rows for the same recommendation/resource are one impacted resource.
+			{
+				RecommendationID: impacted.RecommendationID,
+				ResourceID:       "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Test/widgets/ONE",
+				Category:         models.CategorySecurity,
+				Impact:           models.ImpactHigh,
+			},
+			// Undefined findings did not create Recommendations rows before the summary refactor.
+			{
+				RecommendationID: "undefined",
+				ResourceID:       "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Test/widgets/two",
+				Category:         models.CategorySecurity,
+				Impact:           models.ImpactHigh,
+			},
+		},
+		ResourceTypeCount: []*models.ResourceTypeCount{{
+			ResourceType: "Microsoft.Test/widgets",
+			Count:        1,
+		}},
+	}
+
+	got := data.RecommendationsTable()
+	want := [][]string{
+		{
+			"Implemented",
+			"Number of Impacted Resources",
+			"Azure Service / Well-Architected",
+			"Recommendation Source",
+			"Azure Service Category / Well-Architected Area",
+			"Azure Service / Well-Architected Topic",
+			"Category",
+			"Recommendation",
+			"Impact",
+			"Best Practices Guidance",
+			"Read More",
+			"Recommendation Id",
+		},
+		{
+			"N/A", "0", "Azure Service", "APRL", "Microsoft.Other", "things",
+			string(models.CategoryHighAvailability), "Configure other thing", string(models.ImpactLow),
+			"Long description", "https://example.test/learn", "rec-not-deployed",
+		},
+		{
+			"true", "0", "Azure Service", "APRL", "Microsoft.Test", "widgets",
+			string(models.CategoryGovernance), "Keep widget clean", string(models.ImpactMedium),
+			"Long description", "https://example.test/learn", "rec-clean",
+		},
+		{
+			"false", "1", "Azure Service", "APRL", "Microsoft.Test", "widgets",
+			string(models.CategorySecurity), "Fix impacted widget", string(models.ImpactHigh),
+			"Long description", "https://example.test/learn", "rec-impacted",
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RecommendationsTable contract changed:\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func graphRecommendation(id, resourceType, recommendation, category, impact string) *models.GraphRecommendation {
+	result := &models.GraphRecommendation{
+		RecommendationID: id,
+		ResourceType:     resourceType,
+		Recommendation:   recommendation,
+		Category:         category,
+		Impact:           impact,
+		Source:           "APRL",
+		LongDescription:  "Long description",
+	}
+	result.LearnMoreLink = append(result.LearnMoreLink, struct {
+		Name string `yaml:"name"`
+		Url  string `yaml:"url"`
+	}{
+		Name: "Learn",
+		Url:  "https://example.test/learn",
+	})
+	return result
+}
 
 func TestNewReportData(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
# Description

Adds a dedicated **findings summary** stage to the scan pipeline that computes aggregate statistics (total recommendations, counts by severity and category) at the end of every scan.

Currently callers have to manually iterate all recommendations to compute summary stats — this is duplicated across renderers. A single pipeline stage that builds a `Summary` object makes that data available to all downstream stages (reports, gates, notifications) without extra work.

This is the **base branch** for all other feature PRs in this series.

### Changes
- New `internal/findings` package with `Summary` type and builder logic
- New `FindingsSummaryStage` added to the scan pipeline
- `ReportData` gains a `Summary` field consumed by the Excel/CSV renderer
- `Scan` / `ScanPlugins` now return `(*ReportData, error)` instead of calling `log.Fatal`
- `validateAndPrepareFilters` returns error instead of fatally exiting

## Issue reference

Closes #982

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing