### PR TITLE
feat: add tag-based resource include/exclude filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,9 @@ azqr:
       - <resource_group_resource_id> # format: /subscriptions/<subscription_id>/resourceGroups/<resource_group_name>
     resourceTypes:
       - <resource type abbreviation> # format: Abbreviation of the resource type. For example: "vm" for "Microsoft.Compute/virtualMachines"
+    tags:
+      env: prod
+      team: platform
   exclude:
     subscriptions:
       - <subscription_id> # format: <subscription_id>
@@ -486,12 +489,11 @@ azqr:
       - <service_resource_id> # format: /subscriptions/<subscription_id>/resourceGroups/<resource_group_name>/providers/<service_provider>/<service_name>
     recommendations:
       - <recommendation_id> # format: <recommendation_id>
+    tags:
+      lifecycle: retired
 ```
 
-Then run the scan with the `--filters` flag:
-
-```bash
-azqr scan --filters <path_to_yaml_file>
+All `include.tags` entries must match. Any matching `exclude.tags` entry removes the resource, and exclusion takes precedence. Tag keys are case-insensitive; values are matched exactly.
 ```
 
 > Check the [rules](https://azure.github.io/azqr/docs/recommendations/) to get the recommendation ids.

--- a/docs/content/en/docs/Usage/_index.md
+++ b/docs/content/en/docs/Usage/_index.md
@@ -196,6 +196,9 @@ azqr:
       - <resource_group_resource_id> # format: /subscriptions/<subscription_id>/resourceGroups/<resource_group_name>
     resourceTypes:
       - <resource type abbreviation> # format: Abbreviation of the resource type. For example: "vm" for "Microsoft.Compute/virtualMachines"
+    tags:
+      env: prod
+      team: platform
   exclude:
     subscriptions:
       - <subscription_id> # format: <subscription_id>
@@ -205,12 +208,11 @@ azqr:
       - <service_resource_id> # format: /subscriptions/<subscription_id>/resourceGroups/<resource_group_name>/providers/<service_provider>/<service_name>
     recommendations:
       - <recommendation_id> # format: <recommendation_id>
+    tags:
+      lifecycle: retired
 ```
 
-Then run the scan with the `--filters` flag:
-
-```bash
-./azqr scan --filters <path_to_yaml_file>
+All tags under `include.tags` must match. Any matching tag under `exclude.tags` removes the resource, and exclusion takes precedence. Tag keys are case-insensitive; tag values are matched exactly.
 ```
 
 > Check the [rules](https://azure.github.io/azqr/docs/recommendations/) to get the recommendation ids.

--- a/examples/filters/containers-filters.yml
+++ b/examples/filters/containers-filters.yml
@@ -7,3 +7,10 @@ azqr:
       - cae
       - ci
       - cr
+    # All include tags must match. Tag keys are case-insensitive; values are exact.
+    tags:
+      env: prod
+  exclude:
+    # Any matching exclude tag removes the resource, even when include tags match.
+    tags:
+      lifecycle: retired

--- a/internal/models/filters.go
+++ b/internal/models/filters.go
@@ -23,26 +23,31 @@ type (
 		iSubscriptions   map[string]bool
 		iResourceGroups  map[string]bool
 		iResourceTypes   map[string]bool
+		iTags            map[string]string
 		xSubscriptions   map[string]bool
 		xResourceGroups  map[string]bool
 		xServices        map[string]bool
 		xRecommendations map[string]bool
+		xTags            map[string]string
+		resourceScope    map[string]bool
 		Scanners         []IAzureScanner
 	}
 
 	// ExcludeFilter - Struct for ExcludeFilter
 	ExcludeFilter struct {
-		Subscriptions   []string `yaml:"subscriptions,flow" json:"subscriptions"`
-		ResourceGroups  []string `yaml:"resourceGroups,flow" json:"resourceGroups"`
-		Services        []string `yaml:"services,flow" json:"services"`
-		Recommendations []string `yaml:"recommendations,flow" json:"recommendations"`
+		Subscriptions   []string          `yaml:"subscriptions,flow" json:"subscriptions"`
+		ResourceGroups  []string          `yaml:"resourceGroups,flow" json:"resourceGroups"`
+		Services        []string          `yaml:"services,flow" json:"services"`
+		Recommendations []string          `yaml:"recommendations,flow" json:"recommendations"`
+		Tags            map[string]string `yaml:"tags" json:"tags"`
 	}
 
 	// IncludeFilter - Struct for IncludeFilter
 	IncludeFilter struct {
-		Subscriptions  []string `yaml:"subscriptions,flow" json:"subscriptions"`
-		ResourceGroups []string `yaml:"resourceGroups,flow" json:"resourceGroups"`
-		ResourceTypes  []string `yaml:"resourceTypes,flow"`
+		Subscriptions  []string          `yaml:"subscriptions,flow" json:"subscriptions"`
+		ResourceGroups []string          `yaml:"resourceGroups,flow" json:"resourceGroups"`
+		ResourceTypes  []string          `yaml:"resourceTypes,flow"`
+		Tags           map[string]string `yaml:"tags" json:"tags"`
 	}
 )
 
@@ -78,6 +83,54 @@ func (e *AzqrFilter) IsSubscriptionExcluded(subscriptionID string) bool {
 }
 
 func (e *AzqrFilter) IsServiceExcluded(resourceID string) bool {
+	if e.isServiceStructurallyExcluded(resourceID) {
+		return true
+	}
+
+	if !e.hasTagFilters() {
+		return false
+	}
+
+	if included, ok := e.resourceScopeDecision(resourceID); ok {
+		return !included
+	}
+	if len(e.iTags) > 0 {
+		log.Debug().Msgf("Service is excluded because tag-filter scope is unknown: %s", resourceID)
+		return true
+	}
+	log.Debug().Msgf("Service tag-filter scope is unknown; retaining resource for exclude-only filters: %s", resourceID)
+	return false
+}
+
+// IsResourceExcluded evaluates structural and tag filters during resource discovery.
+func (e *AzqrFilter) IsResourceExcluded(resourceID string, tags map[string]string) bool {
+	if e.isServiceStructurallyExcluded(resourceID) {
+		return true
+	}
+
+	normalizedTags := normalizeTags(tags)
+	for key, value := range e.xTags {
+		if resourceValue, ok := normalizedTags[key]; ok && resourceValue == value {
+			return true
+		}
+	}
+	for key, value := range e.iTags {
+		if resourceValue, ok := normalizedTags[key]; !ok || resourceValue != value {
+			return true
+		}
+	}
+	return false
+}
+
+// SetResourceScope records the tag-filter decision for downstream scan results.
+func (e *AzqrFilter) SetResourceScope(resourceID string, included bool) {
+	if e.resourceScope == nil {
+		e.resourceScope = make(map[string]bool)
+	}
+	e.resourceScope[strings.ToLower(resourceID)] = included
+}
+
+func (e *AzqrFilter) isServiceStructurallyExcluded(resourceID string) bool {
 	t := GetResourceTypeFromResourceID(resourceID)
 	if _, included := e.iResourceTypes[strings.ToLower(t)]; included {
 		sID := GetSubscriptionFromResourceID(resourceID)
@@ -147,12 +200,14 @@ func NewFilters() *Filters {
 				Subscriptions:  []string{},
 				ResourceGroups: []string{},
 				ResourceTypes:  []string{},
+				Tags:           map[string]string{},
 			},
 			Exclude: &ExcludeFilter{
 				Subscriptions:   []string{},
 				ResourceGroups:  []string{},
 				Services:        []string{},
 				Recommendations: []string{},
+				Tags:            map[string]string{},
 			},
 			Scanners: []IAzureScanner{},
 		},
@@ -174,6 +229,20 @@ func LoadFilters(filterFile string, scannerKeys []string) *Filters {
 		if err != nil {
 			log.Fatal().Err(err).Msgf("failed parsing yaml from file: %s", filterFile)
 		}
+
+		if filters.Azqr == nil {
+			filters.Azqr = NewFilters().Azqr
+		}
+		if filters.Azqr.Include == nil {
+			filters.Azqr.Include = NewFilters().Azqr.Include
+		}
+		if filters.Azqr.Exclude == nil {
+			filters.Azqr.Exclude = NewFilters().Azqr.Exclude
+		}
+
+		filters.Azqr.iTags = normalizeTags(filters.Azqr.Include.Tags)
+		filters.Azqr.xTags = normalizeTags(filters.Azqr.Exclude.Tags)
+		filters.Azqr.resourceScope = make(map[string]bool)
 	}
 
 	filters.Azqr.iSubscriptions = make(map[string]bool)
@@ -266,6 +335,32 @@ func LoadFilters(filterFile string, scannerKeys []string) *Filters {
 	}
 
 	return filters
+}
+
+func (e *AzqrFilter) hasTagFilters() bool {
+	return len(e.iTags) > 0 || len(e.xTags) > 0
+}
+
+func (e *AzqrFilter) resourceScopeDecision(resourceID string) (bool, bool) {
+	id := strings.ToLower(resourceID)
+	for {
+		if included, ok := e.resourceScope[id]; ok {
+			return included, true
+		}
+		lastSlash := strings.LastIndexByte(id, '/')
+		if lastSlash <= 0 {
+			return false, false
+		}
+		id = id[:lastSlash]
+	}
+}
+
+func normalizeTags(tags map[string]string) map[string]string {
+	normalized := make(map[string]string, len(tags))
+	for key, value := range tags {
+		normalized[strings.ToLower(strings.TrimSpace(key))] = value
+	}
+	return normalized
 }
 
 func (e *AzqrFilter) isResourceGroupExcluded(resourceGroupID string) bool {

--- a/internal/models/filters_test.go
+++ b/internal/models/filters_test.go
@@ -15,123 +15,82 @@ func TestValidateResourceGroupID(t *testing.T) {
 		expectError     bool
 		errorContains   string
 	}{
-		{
-			name:            "valid resource group ID",
-			resourceGroupID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg",
-			expectError:     false,
-		},
-		{
-			name:            "invalid format - just resource group name",
-			resourceGroupID: "test-rg",
-			expectError:     true,
-			errorContains:   "has incorrect format",
-		},
-		{
-			name:            "invalid format - missing leading slash",
-			resourceGroupID: "subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg",
-			expectError:     true,
-			errorContains:   "has incorrect format",
-		},
-		{
-			name:            "invalid format - missing subscriptions segment",
-			resourceGroupID: "/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg",
-			expectError:     true,
-			errorContains:   "has incorrect format",
-		},
-		{
-			name:            "invalid format - missing resourceGroups segment",
-			resourceGroupID: "/subscriptions/12345678-1234-1234-1234-123456789012/test-rg",
-			expectError:     true,
-			errorContains:   "has incorrect format",
-		},
-		{
-			name:            "invalid format - wrong resourceGroups segment",
-			resourceGroupID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroup/test-rg",
-			expectError:     true,
-			errorContains:   "has incorrect format",
-		},
-		{
-			name:            "invalid format - empty subscription ID",
-			resourceGroupID: "/subscriptions//resourceGroups/test-rg",
-			expectError:     true,
-			errorContains:   "has empty subscription ID",
-		},
-		{
-			name:            "invalid format - empty resource group name",
-			resourceGroupID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/",
-			expectError:     true,
-			errorContains:   "has empty resource group name",
-		},
-		{
-			name:            "invalid format - too many segments",
-			resourceGroupID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers",
-			expectError:     true,
-			errorContains:   "has incorrect format",
-		},
-		{
-			name:            "invalid format - too few segments",
-			resourceGroupID: "/subscriptions/12345678-1234-1234-1234-123456789012",
-			expectError:     true,
-			errorContains:   "has incorrect format",
-		},
+		{name: "valid", resourceGroupID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg"},
+		{name: "name only", resourceGroupID: "test-rg", expectError: true, errorContains: "incorrect format"},
+		{name: "missing leading slash", resourceGroupID: "subscriptions/123/resourceGroups/test-rg", expectError: true, errorContains: "incorrect format"},
+		{name: "missing subscriptions segment", resourceGroupID: "/123/resourceGroups/test-rg", expectError: true, errorContains: "incorrect format"},
+		{name: "wrong resource groups segment", resourceGroupID: "/subscriptions/123/resourceGroup/test-rg", expectError: true, errorContains: "incorrect format"},
+		{name: "empty subscription", resourceGroupID: "/subscriptions//resourceGroups/test-rg", expectError: true, errorContains: "empty subscription ID"},
+		{name: "empty resource group", resourceGroupID: "/subscriptions/123/resourceGroups/", expectError: true, errorContains: "empty resource group name"},
+		{name: "too many segments", resourceGroupID: "/subscriptions/123/resourceGroups/test-rg/providers", expectError: true, errorContains: "incorrect format"},
+		{name: "too few segments", resourceGroupID: "/subscriptions/123", expectError: true, errorContains: "incorrect format"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateResourceGroupID(tt.resourceGroupID)
-
 			if tt.expectError {
 				if err == nil {
-					t.Errorf("expected error for resourceGroupID '%s' but got none", tt.resourceGroupID)
-				} else if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error to contain '%s' but got '%s'", tt.errorContains, err.Error())
+					t.Fatal("expected validation error")
 				}
-			} else {
-				if err != nil {
-					t.Errorf("unexpected error for resourceGroupID '%s': %v", tt.resourceGroupID, err)
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Fatalf("error %q does not contain %q", err, tt.errorContains)
 				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}
 }
 
 func TestLoadFiltersValidation(t *testing.T) {
-	// Test with valid resource group IDs - should not panic or error
-	validFilters := &Filters{
-		Azqr: &AzqrFilter{
-			Include: &IncludeFilter{
-				Subscriptions:  []string{},
-				ResourceGroups: []string{"/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg"},
-				ResourceTypes:  []string{},
-			},
-			Exclude: &ExcludeFilter{
-				Subscriptions:   []string{},
-				ResourceGroups:  []string{"/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/exclude-rg"},
-				Services:        []string{},
-				Recommendations: []string{},
-			},
-		},
-	}
-
-	// This should not cause any validation errors
-	if err := validateResourceGroupID("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg"); err != nil {
-		t.Errorf("valid resource group ID failed validation: %v", err)
-	}
-
-	if err := validateResourceGroupID("/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/exclude-rg"); err != nil {
-		t.Errorf("valid resource group ID failed validation: %v", err)
-	}
-
-	// Test validation of individual components
-	for _, rgID := range validFilters.Azqr.Include.ResourceGroups {
-		if err := validateResourceGroupID(rgID); err != nil {
-			t.Errorf("include resource group validation failed: %v", err)
+	for _, id := range []string{
+		"/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg",
+		"/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/exclude-rg",
+	} {
+		if err := validateResourceGroupID(id); err != nil {
+			t.Errorf("valid resource group ID failed validation: %v", err)
 		}
 	}
+}
 
-	for _, rgID := range validFilters.Azqr.Exclude.ResourceGroups {
-		if err := validateResourceGroupID(rgID); err != nil {
-			t.Errorf("exclude resource group validation failed: %v", err)
-		}
+func TestTagFilters(t *testing.T) {
+	filters := NewFilters()
+	filters.Azqr.iResourceTypes = map[string]bool{"microsoft.test/widgets": true}
+	filters.Azqr.iTags = map[string]string{"env": "prod", "team": "platform"}
+	filters.Azqr.xTags = map[string]string{"lifecycle": "retired"}
+	resourceID := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Test/widgets/one"
+
+	tests := []struct {
+		name string
+		tags map[string]string
+		want bool
+	}{
+		{name: "all includes match", tags: map[string]string{"ENV": "prod", "Team": "platform"}},
+		{name: "include missing", tags: map[string]string{"env": "prod"}, want: true},
+		{name: "value comparison is exact", tags: map[string]string{"env": "Prod", "team": "platform"}, want: true},
+		{name: "exclude wins", tags: map[string]string{"env": "prod", "team": "platform", "lifecycle": "retired"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filters.Azqr.IsResourceExcluded(resourceID, tt.tags); got != tt.want {
+				t.Fatalf("IsResourceExcluded() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTagScopeAppliesToChildResource(t *testing.T) {
+	filters := NewFilters()
+	filters.Azqr.iResourceTypes = map[string]bool{"microsoft.test/widgets": true}
+	filters.Azqr.iTags = map[string]string{"env": "prod"}
+	parent := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Test/widgets/one"
+	filters.Azqr.SetResourceScope(parent, true)
+
+	if filters.Azqr.IsServiceExcluded(parent + "/slots/blue") {
+		t.Fatal("child resource should inherit included parent scope")
 	}
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -49,6 +49,7 @@ type (
 		SkuFamily      string
 		SkuCapacity    int
 		Kind           string
+		Tags           map[string]string
 		SLA            string
 	}
 

--- a/internal/pipeline/stage_graph_scan.go
+++ b/internal/pipeline/stage_graph_scan.go
@@ -49,13 +49,7 @@ func (s *GraphScanStage) Execute(ctx *ScanContext) error {
 		Msg("Graph Phase 1: Recommendations listed")
 
 	// Get resource type counts for filtering — fetched once and reused below.
-	resourceScanner := scanners.ResourceDiscovery{}
-	resourceTypeCount := resourceScanner.GetCountPerResourceTypeAndSubscription(
-		ctx.Ctx,
-		ctx.Cred,
-		ctx.Subscriptions,
-		ctx.Params.Filters,
-	)
+	resourceTypeCount := scanners.CountResourcesByTypeAndSubscription(ctx.ReportData.Resources, ctx.Subscriptions)
 	ctx.ReportData.ResourceTypeCount = resourceTypeCount
 
 	log.Debug().

--- a/internal/scanners/build_results_test.go
+++ b/internal/scanners/build_results_test.go
@@ -244,34 +244,3 @@ func TestBuildResources(t *testing.T) {
 	})
 }
 
-func TestBuildResourceTypeCounts(t *testing.T) {
-	filters := includeAllFilters()
-	subscriptions := map[string]string{"sub1": "Sub One"}
-	data := rawRows(
-		`{"subscriptionId":"sub1","type":"Microsoft.Storage/storageAccounts","count_":5}`,
-		`{bad}`,
-	)
-	got := buildResourceTypeCounts(data, subscriptions, filters)
-	if len(got) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(got))
-	}
-	r := got[0]
-	if r.Subscription != "Sub One" || r.ResourceType != "Microsoft.Storage/storageAccounts" || r.Count != 5 {
-		t.Errorf("count mapping wrong: %+v", r)
-	}
-}
-
-func TestBuildResourceTypeCountMap(t *testing.T) {
-	filters := includeAllFilters()
-	data := rawRows(
-		`{"type":"Microsoft.Storage/storageAccounts","count_":7}`,
-		`{bad}`,
-	)
-	got := buildResourceTypeCountMap(data, filters)
-	if len(got) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(got))
-	}
-	if got["Microsoft.Storage/storageAccounts"] != 7 {
-		t.Errorf("count map wrong: %+v", got)
-	}
-}

--- a/internal/scanners/resources.go
+++ b/internal/scanners/resources.go
@@ -3,6 +3,7 @@ package scanners
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"strings"
 
 	"github.com/Azure/azqr/internal/graph"
@@ -17,7 +18,7 @@ func (sc *ResourceDiscovery) GetAllResources(ctx context.Context, cred azcore.To
 	models.LogResourceTypeScan("Resources")
 
 	graphClient := graph.NewGraphQuery(cred)
-	query := "resources | project id=tostring(id), subscriptionId=tostring(subscriptionId), resourceGroup=tostring(resourceGroup), location=tostring(location), type=tostring(type), name=tostring(name), skuName=tostring(coalesce(sku.name, properties.sku.name, properties.hardwareProfile.vmSize, properties.tier, sku)), skuTier=tostring(coalesce(sku.tier, properties.sku.tier)), skuFamily=tostring(coalesce(sku.family, properties.sku.family)), skuCapacity=tolong(coalesce(sku.capacity, properties.sku.capacity, 0)), ['kind']=tostring(kind) | order by subscriptionId, resourceGroup"
+	query := "resources | project id=tostring(id), subscriptionId=tostring(subscriptionId), resourceGroup=tostring(resourceGroup), location=tostring(location), type=tostring(type), name=tostring(name), tags, skuName=tostring(coalesce(sku.name, properties.sku.name, properties.hardwareProfile.vmSize, properties.tier, sku)), skuTier=tostring(coalesce(sku.tier, properties.sku.tier)), skuFamily=tostring(coalesce(sku.family, properties.sku.family)), skuCapacity=tolong(coalesce(sku.capacity, properties.sku.capacity, 0)), ['kind']=tostring(kind) | order by subscriptionId, resourceGroup"
 	log.Debug().Msg(query)
 	result, err := graphClient.Query(ctx, query, subscriptions)
 	if err != nil {
@@ -34,17 +35,18 @@ func buildResources(data []json.RawMessage, filters *models.Filters) ([]*models.
 	excludedResources := []*models.Resource{}
 	if data != nil {
 		type resourceRow struct {
-			ID             string `json:"id"`
-			SubscriptionID string `json:"subscriptionId"`
-			ResourceGroup  string `json:"resourceGroup"`
-			Location       string `json:"location"`
-			Type           string `json:"type"`
-			Name           string `json:"name"`
-			SkuName        string `json:"skuName"`
-			SkuTier        string `json:"skuTier"`
-			SkuFamily      string `json:"skuFamily"`
-			SkuCapacity    int    `json:"skuCapacity"`
-			Kind           string `json:"kind"`
+			ID             string            `json:"id"`
+			SubscriptionID string            `json:"subscriptionId"`
+			ResourceGroup  string            `json:"resourceGroup"`
+			Location       string            `json:"location"`
+			Type           string            `json:"type"`
+			Name           string            `json:"name"`
+			SkuName        string            `json:"skuName"`
+			SkuTier        string            `json:"skuTier"`
+			SkuFamily      string            `json:"skuFamily"`
+			SkuCapacity    int               `json:"skuCapacity"`
+			Kind           string            `json:"kind"`
+			Tags           map[string]string `json:"tags"`
 		}
 		for _, raw := range data {
 			var r resourceRow
@@ -65,9 +67,14 @@ func buildResources(data []json.RawMessage, filters *models.Filters) ([]*models.
 				SkuFamily:      r.SkuFamily,
 				SkuCapacity:    r.SkuCapacity,
 				Kind:           r.Kind,
+				Tags:           r.Tags,
 			}
 
-			if filters != nil && filters.Azqr.IsServiceExcluded(resource.ID) {
+			excluded := filters != nil && filters.Azqr.IsResourceExcluded(resource.ID, resource.Tags)
+			if filters != nil {
+				filters.Azqr.SetResourceScope(resource.ID, !excluded)
+			}
+			if excluded {
 				excludedResources = append(
 					excludedResources,
 					resource)
@@ -81,19 +88,35 @@ func buildResources(data []json.RawMessage, filters *models.Filters) ([]*models.
 	return resources, excludedResources
 }
 
-func (sc ResourceDiscovery) GetCountPerResourceTypeAndSubscription(ctx context.Context, cred azcore.TokenCredential, subscriptions map[string]string, filters *models.Filters) []*models.ResourceTypeCount {
-	models.LogResourceTypeScan("Resource Count per Subscription and Type")
-
-	graphClient := graph.NewGraphQuery(cred)
-	query := "resources | summarize count() by subscriptionId, type | order by subscriptionId, type"
-	log.Debug().Msg(query)
-
-	result, err := graphClient.Query(ctx, query, subscriptions)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to query Azure Resource Graph for resource counts by subscription and type")
-		return nil
+// CountResourcesByTypeAndSubscription derives report counts from filtered inventory.
+func CountResourcesByTypeAndSubscription(resources []*models.Resource, subscriptions map[string]string) []*models.ResourceTypeCount {
+	type countKey struct {
+		subscriptionID string
+		resourceType   string
 	}
-	return buildResourceTypeCounts(result.Data, subscriptions, filters)
+	counts := make(map[countKey]float64)
+	for _, resource := range resources {
+		if resource == nil {
+			continue
+		}
+		counts[countKey{subscriptionID: resource.SubscriptionID, resourceType: resource.Type}]++
+	}
+
+	results := make([]*models.ResourceTypeCount, 0, len(counts))
+	for key, count := range counts {
+		results = append(results, &models.ResourceTypeCount{
+			Subscription: subscriptions[key.subscriptionID],
+			ResourceType: key.resourceType,
+			Count:        count,
+		})
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Subscription != results[j].Subscription {
+			return results[i].Subscription < results[j].Subscription
+		}
+		return results[i].ResourceType < results[j].ResourceType
+	})
+	return results
 }
 
 // buildResourceTypeCounts maps raw count-by-subscription-and-type rows to

--- a/internal/scanners/resources.go
+++ b/internal/scanners/resources.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"sort"
-	"strings"
 
 	"github.com/Azure/azqr/internal/graph"
 	"github.com/Azure/azqr/internal/models"
@@ -119,74 +118,4 @@ func CountResourcesByTypeAndSubscription(resources []*models.Resource, subscript
 	return results
 }
 
-// buildResourceTypeCounts maps raw count-by-subscription-and-type rows to
-// ResourceTypeCount records, applying the resource-type exclusion filter.
-func buildResourceTypeCounts(data []json.RawMessage, subscriptions map[string]string, filters *models.Filters) []*models.ResourceTypeCount {
-	resources := []*models.ResourceTypeCount{}
-	if data != nil {
-		type countBySubRow struct {
-			SubscriptionID string  `json:"subscriptionId"`
-			Type           string  `json:"type"`
-			Count          float64 `json:"count_"`
-		}
-		for _, raw := range data {
-			var r countBySubRow
-			if err := json.Unmarshal(raw, &r); err != nil {
-				log.Warn().Err(err).Msg("Skipping malformed resource count row")
-				continue
-			}
 
-			if filters.Azqr.IsResourceTypeExcluded(strings.ToLower(r.Type)) {
-				continue
-			}
-
-			resources = append(resources, &models.ResourceTypeCount{
-				Subscription: subscriptions[r.SubscriptionID],
-				ResourceType: r.Type,
-				Count:        r.Count,
-			})
-		}
-	}
-	return resources
-}
-
-func (sc ResourceDiscovery) GetCountPerResourceType(ctx context.Context, cred azcore.TokenCredential, subscriptions map[string]string, filters *models.Filters) map[string]float64 {
-	models.LogResourceTypeScan("Resource Count per Type")
-
-	graphClient := graph.NewGraphQuery(cred)
-	query := "resources | summarize count() by type | order by type"
-	log.Debug().Msg(query)
-
-	result, err := graphClient.Query(ctx, query, subscriptions)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to query Azure Resource Graph for resource counts by type")
-		return map[string]float64{}
-	}
-	return buildResourceTypeCountMap(result.Data, filters)
-}
-
-// buildResourceTypeCountMap maps raw count-by-type rows to a type→count map,
-// applying the resource-type exclusion filter.
-func buildResourceTypeCountMap(data []json.RawMessage, filters *models.Filters) map[string]float64 {
-	resources := map[string]float64{}
-	if data != nil {
-		type countByTypeRow struct {
-			Type  string  `json:"type"`
-			Count float64 `json:"count_"`
-		}
-		for _, raw := range data {
-			var r countByTypeRow
-			if err := json.Unmarshal(raw, &r); err != nil {
-				log.Warn().Err(err).Msg("Skipping malformed resource type count row")
-				continue
-			}
-
-			if filters.Azqr.IsResourceTypeExcluded(strings.ToLower(r.Type)) {
-				continue
-			}
-
-			resources[r.Type] = r.Count
-		}
-	}
-	return resources
-}

--- a/internal/scanners/resources_test.go
+++ b/internal/scanners/resources_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package scanners
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/Azure/azqr/internal/models"
+)
+
+func TestBuildResourcesAppliesTagFilters(t *testing.T) {
+	data := []json.RawMessage{
+		json.RawMessage(`{"id":"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/prod","subscriptionId":"sub","resourceGroup":"rg","type":"Microsoft.Compute/virtualMachines","name":"prod","tags":{"Env":"prod"}}`),
+		json.RawMessage(`{"id":"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/dev","subscriptionId":"sub","resourceGroup":"rg","type":"Microsoft.Compute/virtualMachines","name":"dev","tags":{"env":"dev"}}`),
+	}
+
+	// LoadFilters normally initializes these maps and scanners. Populate the scanner
+	// type through a filter file is unnecessary for this mapping-focused test.
+	filters := initializeTestFilters(t)
+	included, excluded := buildResources(data, filters)
+
+	if len(included) != 1 || included[0].Name != "prod" {
+		t.Fatalf("unexpected included resources: %+v", included)
+	}
+	if len(excluded) != 1 || excluded[0].Name != "dev" {
+		t.Fatalf("unexpected excluded resources: %+v", excluded)
+	}
+}
+
+func TestCountResourcesByTypeAndSubscription(t *testing.T) {
+	resources := []*models.Resource{
+		{SubscriptionID: "sub", Type: "Microsoft.Test/widgets"},
+		{SubscriptionID: "sub", Type: "Microsoft.Test/widgets"},
+	}
+	got := CountResourcesByTypeAndSubscription(resources, map[string]string{"sub": "Subscription"})
+	if len(got) != 1 || got[0].Count != 2 || got[0].Subscription != "Subscription" {
+		t.Fatalf("unexpected counts: %+v", got)
+	}
+}
+
+func initializeTestFilters(t *testing.T) *models.Filters {
+	t.Helper()
+	original, existed := models.ScannerList["vm"]
+	models.ScannerList["vm"] = []models.IAzureScanner{testResourceScanner{}}
+	t.Cleanup(func() {
+		if existed {
+			models.ScannerList["vm"] = original
+		} else {
+			delete(models.ScannerList, "vm")
+		}
+	})
+	// NewFilters cannot expose its internal indexes to this package, so use a real
+	// temporary YAML file through LoadFilters.
+	path := t.TempDir() + "/filters.yml"
+	content := []byte("azqr:\n  include:\n    tags:\n      env: prod\n")
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+	return models.LoadFilters(path, []string{"vm"})
+}
+
+type testResourceScanner struct{}
+
+func (testResourceScanner) ServiceName() string { return "Test" }
+func (testResourceScanner) ResourceTypes() []string {
+	return []string{"Microsoft.Compute/virtualMachines"}
+}

--- a/jumpstart_drops/azqr-tutorial/_index.md
+++ b/jumpstart_drops/azqr-tutorial/_index.md
@@ -155,6 +155,9 @@ azqr:
       - <resource_group_resource_id>
     resourceTypes:
       - <resource type abbreviation>
+    tags:
+      env: prod
+      team: platform
   exclude:
     subscriptions:
       - <subscription_id>
@@ -164,7 +167,11 @@ azqr:
       - <service_resource_id>
     recommendations:
       - <recommendation_id>
+    tags:
+      lifecycle: retired
 ```
+
+All include tags must match. Any matching exclude tag removes the resource, and exclusion takes precedence. Tag keys are case-insensitive; values are matched exactly.
 
 ### Running Scan with Filters
 


### PR DESCRIPTION
# Description

Allows users to **include or exclude Azure resources from scans based on resource tags**, in addition to the existing name/type/resource-group filters.

Large environments often use tags (e.g. `env=prod`, `team=platform`) to classify resources. Scoping a scan to only tagged resources — or skipping resources with certain tags — reduces noise and makes results actionable for specific teams.

### Changes
- `Resource` struct gains a `Tags map[string]string` field populated from the Graph query
- `filters.yml` supports new `include.tags` and `exclude.tags` keys
- `IsResourceExcluded` / `SetResourceScope` cache the tag-filter decision during discovery
- `IsServiceExcluded` looks up the cached decision for downstream scan stages
- `CountResourcesByTypeAndSubscription` re-uses the already-filtered resource list (no extra Graph API call)
- Example filter file and documentation updated with tag examples

## Issue reference

Closes #983

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing