### PR TITLE
feat: add scan history store and trend subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,17 @@ azqr scan --xlsx=false --sarif --output-name azqr-results
 
 SARIF results are aggregated per impacted recommendation and use logical Azure locations. They support security dashboards, but not PR diff line annotations without a separate deployed-resource-to-IaC source mapping.
 
+## Scan history and trends
+
+Record aggregate-only history and inspect recent scans:
+
+```bash
+azqr scan --history
+azqr trend --last 12
+```
+
+Use `--history-file <path>` on either command to override the default `history.jsonl` under the user config directory. Records are isolated by an opaque scan-scope ID and do not store resource or subscription IDs.
+
 ## Filtering Recommendations and more
 
 You can configure Azure Quick Review to include or exclude specific subscriptions or resource groups and also exclude services or recommendations. To do so, create a `yaml` file with the following format:

--- a/cmd/azqr/commands/commands_test.go
+++ b/cmd/azqr/commands/commands_test.go
@@ -66,7 +66,7 @@ func TestCheckGateSuppressesOutputOnlyOnFailure(t *testing.T) {
 }
 
 func TestRootCommandHasSubcommands(t *testing.T) {
-	expectedCommands := []string{"scan", "compare", "rules", "types", "plugins"}
+	expectedCommands := []string{"scan", "compare", "trend", "rules", "types", "plugins"}
 
 	for _, expectedCmd := range expectedCommands {
 		found := false
@@ -122,6 +122,8 @@ func TestScanCommandHasRequiredFlags(t *testing.T) {
 		{"filters", "string"},
 		{"fail-on", "string"},
 		{"sarif", "bool"},
+		{"history", "bool"},
+		{"history-file", "string"},
 	}
 
 	for _, rf := range requiredFlags {

--- a/cmd/azqr/commands/scan.go
+++ b/cmd/azqr/commands/scan.go
@@ -6,9 +6,11 @@ package commands
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Azure/azqr/internal/findings"
 	"github.com/Azure/azqr/internal/gate"
+	"github.com/Azure/azqr/internal/history"
 	"github.com/Azure/azqr/internal/models"
 	"github.com/Azure/azqr/internal/pipeline"
 	"github.com/Azure/azqr/internal/profiling"
@@ -33,6 +35,8 @@ func init() {
 	scanCmd.PersistentFlags().StringP("filters", "e", "", "Filters file (YAML format)")
 	scanCmd.PersistentFlags().StringP("fail-on", "", "", "Fail when impacted recommendations meet or exceed this impact (High, Medium, Low)")
 	scanCmd.PersistentFlags().Bool("sarif", false, "Create a SARIF 2.1.0 report")
+	scanCmd.PersistentFlags().Bool("history", false, "Append an aggregate scan snapshot to local history")
+	scanCmd.PersistentFlags().String("history-file", "", "History JSONL path (defaults to the user config directory)")
 
 	// Conditionally add profiling flags if profiling is available and enabled via environment
 	// Build with -tags debug to enable profiling features
@@ -72,6 +76,8 @@ func scan(cmd *cobra.Command, scannerKeys []string) error {
 	filtersFile, _ := cmd.Flags().GetString("filters")
 	failOn, _ := cmd.Flags().GetString("fail-on")
 	sarifEnabled, _ := cmd.Flags().GetBool("sarif")
+	historyEnabled, _ := cmd.Flags().GetBool("history")
+	historyFile, _ := cmd.Flags().GetString("history-file")
 	pluginNames, _ := cmd.Flags().GetStringSlice("plugin")
 
 	var gateCriterion gate.Criterion
@@ -128,13 +134,32 @@ func scan(cmd *cobra.Command, scannerKeys []string) error {
 		MemProfile:             memProfile,
 		TraceProfile:           traceProfile,
 		Sarif:                  sarifEnabled,
+		History:                historyEnabled || historyFile != "",
+		HistoryFile:            historyFile,
 		Version:                version,
 	}
+
+	scopeID, err := history.ScopeID(&params)
+	if err != nil {
+		return err
+	}
+	params.ScopeID = scopeID
 
 	scanner := pipeline.Scanner{}
 	reportData, err := scanner.Scan(&params)
 	if err != nil {
 		return err
+	}
+	reportData.ScopeID = scopeID
+	if params.History {
+		path, err := history.ResolvePath(params.HistoryFile)
+		if err != nil {
+			return err
+		}
+		record := history.NewRecord(reportData.Summary, scopeID, version, time.Now())
+		if err := history.Append(path, record); err != nil {
+			return err
+		}
 	}
 	if gateEnabled {
 		return checkGate(cmd, reportData.Summary, gateCriterion)

--- a/cmd/azqr/commands/trend.go
+++ b/cmd/azqr/commands/trend.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/Azure/azqr/internal/history"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	trendCmd.Flags().String("history-file", "", "History JSONL path (defaults to the user config directory)")
+	trendCmd.Flags().Int("last", 12, "Number of recent scans to show")
+	trendCmd.Flags().String("scope", "", "Opaque scan scope ID (defaults to the latest scope)")
+	trendCmd.Flags().String("format", "table", "Output format (table, json)")
+	rootCmd.AddCommand(trendCmd)
+}
+
+var trendCmd = &cobra.Command{
+	Use:   "trend",
+	Short: "Show aggregate scan trends",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		override, _ := cmd.Flags().GetString("history-file")
+		last, _ := cmd.Flags().GetInt("last")
+		scopeID, _ := cmd.Flags().GetString("scope")
+		format, _ := cmd.Flags().GetString("format")
+
+		path, err := history.ResolvePath(override)
+		if err != nil {
+			return err
+		}
+		records, err := history.Read(path)
+		if err != nil {
+			return err
+		}
+		selected, selectedScope, err := history.Select(records, scopeID, last)
+		if err != nil {
+			return err
+		}
+		output, err := history.Render(selected, selectedScope, format)
+		if err != nil {
+			return err
+		}
+		fmt.Println(output)
+		return nil
+	},
+}

--- a/docs/content/en/docs/Usage/_index.md
+++ b/docs/content/en/docs/Usage/_index.md
@@ -320,6 +320,26 @@ azqr scan --fail-on Medium
 
 Supported thresholds are `High`, `Medium`, and `Low`. The gate evaluates deduplicated core azqr and diagnostics findings after requested reports are generated. Advisor, Defender, Policy, cost, status, and plugin datasets are not included.
 
+## Scan history and trends
+
+History is opt-in and stores aggregate counts only:
+
+```bash
+# Uses the default history.jsonl under the user config directory
+azqr scan --history
+
+# Uses a specific history file
+azqr scan --history --history-file ./azqr-history.jsonl
+
+# Shows the latest 12 scans for the most recently recorded scope
+azqr trend
+
+# Machine-readable trend output
+azqr trend --last 20 --format json
+```
+
+Each scan scope receives an opaque ID so subscriptions, resource groups, filters, and enabled recommendation stages are not mixed in one trend. History records do not contain subscription IDs, resource IDs, inventories, or webhook URLs.
+
 ## File Outputs
 
 Azure Quick Review supports `xlsx` (default), `csv`, `json`, and `sarif` file outputs.

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -1,0 +1,297 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package history stores and reads aggregate azqr scan snapshots.
+package history
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Azure/azqr/internal/findings"
+	"github.com/Azure/azqr/internal/models"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// SchemaVersion is the current JSON Lines record schema.
+	SchemaVersion = 1
+	lockTimeout   = 2 * time.Second
+	staleLockAge  = 30 * time.Second
+)
+
+// RecommendationCount stores aggregate data for one impacted recommendation.
+type RecommendationCount struct {
+	ID           string `json:"id"`
+	Impact       string `json:"impact"`
+	Category     string `json:"category"`
+	ResourceType string `json:"resourceType"`
+	Count        int    `json:"count"`
+}
+
+// Record is one aggregate scan snapshot.
+type Record struct {
+	SchemaVersion        int                   `json:"schemaVersion"`
+	Timestamp            time.Time             `json:"timestamp"`
+	AzqrVersion          string                `json:"azqrVersion"`
+	ScopeID              string                `json:"scopeId"`
+	Resources            int                   `json:"resources"`
+	ImpactedResources    int                   `json:"impactedResources"`
+	RecommendationsFound int                   `json:"recommendationsFound"`
+	ImpactedByImpact     map[string]int        `json:"impactedByImpact"`
+	ImpactedByCategory   map[string]int        `json:"impactedByCategory"`
+	Recommendations      []RecommendationCount `json:"recommendations"`
+}
+
+// DefaultPath returns the default per-user history path.
+func DefaultPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user config directory: %w", err)
+	}
+	return filepath.Join(configDir, "azqr", "history.jsonl"), nil
+}
+
+// ResolvePath returns the override or default history path.
+func ResolvePath(override string) (string, error) {
+	if override != "" {
+		return filepath.Clean(override), nil
+	}
+	return DefaultPath()
+}
+
+// ScopeID returns a stable opaque ID for recommendation-relevant scan scope.
+func ScopeID(params *models.ScanParams) (string, error) {
+	if params == nil {
+		return "", errors.New("scan parameters are required")
+	}
+	descriptor := struct {
+		ManagementGroups []string        `json:"managementGroups"`
+		Subscriptions    []string        `json:"subscriptions"`
+		ResourceGroups   []string        `json:"resourceGroups"`
+		ScannerKeys      []string        `json:"scannerKeys"`
+		Stages           []string        `json:"stages"`
+		Filters          *models.Filters `json:"filters"`
+	}{
+		ManagementGroups: sortedCopy(params.ManagementGroups),
+		Subscriptions:    sortedCopy(params.Subscriptions),
+		ResourceGroups:   sortedCopy(params.ResourceGroups),
+		ScannerKeys:      sortedCopy(params.ScannerKeys),
+		Filters:          params.Filters,
+	}
+	if params.Stages != nil {
+		descriptor.Stages = sortedCopy(params.Stages.GetEnabledStages())
+	}
+
+	data, err := json.Marshal(descriptor)
+	if err != nil {
+		return "", fmt.Errorf("marshal scan scope: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:8]), nil
+}
+
+// NewRecord creates a versioned snapshot from a canonical findings summary.
+func NewRecord(summary *findings.Summary, scopeID, azqrVersion string, timestamp time.Time) Record {
+	record := Record{
+		SchemaVersion:      SchemaVersion,
+		Timestamp:          timestamp.UTC(),
+		AzqrVersion:        azqrVersion,
+		ScopeID:            scopeID,
+		ImpactedByImpact:   map[string]int{},
+		ImpactedByCategory: map[string]int{},
+		Recommendations:    []RecommendationCount{},
+	}
+	if summary == nil {
+		return record
+	}
+
+	record.Resources = summary.Resources
+	record.ImpactedResources = summary.ImpactedResources
+	record.RecommendationsFound = summary.RecommendationsFound
+	record.ImpactedByImpact = copyCounts(summary.ImpactedByImpact)
+	record.ImpactedByCategory = copyCounts(summary.ImpactedByCategory)
+	for _, recommendation := range summary.Recommendations {
+		if recommendation.ImpactedResources == 0 {
+			continue
+		}
+		record.Recommendations = append(record.Recommendations, RecommendationCount{
+			ID:           recommendation.ID,
+			Impact:       recommendation.Impact,
+			Category:     recommendation.Category,
+			ResourceType: recommendation.ResourceType,
+			Count:        recommendation.ImpactedResources,
+		})
+	}
+	return record
+}
+
+// Append safely appends one record to a history file.
+func Append(path string, record Record) error {
+	if record.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("unsupported history schema version %d", record.SchemaVersion)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create history directory: %w", err)
+	}
+
+	release, err := acquireLock(path + ".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal history record: %w", err)
+	}
+	data = append(data, '\n')
+
+	file, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("open history file: %w", err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("Failed to close history file")
+		}
+	}()
+	if err := file.Chmod(0600); err != nil {
+		return fmt.Errorf("secure history file: %w", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("append history record: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync history file: %w", err)
+	}
+	return nil
+}
+
+// Read loads and validates all complete history records.
+func Read(path string) ([]Record, error) {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if errors.Is(err, os.ErrNotExist) {
+		return []Record{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read history file: %w", err)
+	}
+
+	lines := bytes.Split(data, []byte{'\n'})
+	records := make([]Record, 0, len(lines))
+	for index, line := range lines {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var record Record
+		if err := json.Unmarshal(line, &record); err != nil {
+			if index == len(lines)-1 && !bytes.HasSuffix(data, []byte{'\n'}) {
+				log.Warn().Msg("Ignoring truncated final history record")
+				break
+			}
+			return nil, fmt.Errorf("parse history record %d: %w", index+1, err)
+		}
+		if record.SchemaVersion != SchemaVersion {
+			return nil, fmt.Errorf("history record %d uses unsupported schema version %d", index+1, record.SchemaVersion)
+		}
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+// Select returns the requested scope and most recent records.
+func Select(records []Record, scopeID string, last int) ([]Record, string, error) {
+	if last < 1 {
+		return nil, "", errors.New("last must be greater than zero")
+	}
+
+	if scopeID == "" {
+		if len(records) == 0 {
+			return []Record{}, "", nil
+		}
+		scopeID = records[len(records)-1].ScopeID
+	}
+
+	selected := make([]Record, 0, len(records))
+	for _, record := range records {
+		if record.ScopeID == scopeID {
+			selected = append(selected, record)
+		}
+	}
+	sort.SliceStable(selected, func(i, j int) bool {
+		return selected[i].Timestamp.Before(selected[j].Timestamp)
+	})
+	if len(selected) > last {
+		selected = selected[len(selected)-last:]
+	}
+	return selected, scopeID, nil
+}
+
+// Latest returns the most recent record for a scope.
+func Latest(records []Record, scopeID string) *Record {
+	var latest *Record
+	for index := range records {
+		record := &records[index]
+		if record.ScopeID != scopeID {
+			continue
+		}
+		if latest == nil || record.Timestamp.After(latest.Timestamp) {
+			latest = record
+		}
+	}
+	return latest
+}
+
+func acquireLock(path string) (func(), error) {
+	deadline := time.Now().Add(lockTimeout)
+	for {
+		file, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+		if err == nil {
+			_ = file.Close()
+			return func() {
+				if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+					log.Warn().Err(removeErr).Msg("Failed to remove history lock")
+				}
+			}, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("create history lock: %w", err)
+		}
+		if stat, statErr := os.Stat(path); statErr == nil && time.Since(stat.ModTime()) > staleLockAge {
+			if removeErr := os.Remove(path); removeErr == nil {
+				continue
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for history lock %s", filepath.Base(path))
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func sortedCopy(values []string) []string {
+	result := append([]string(nil), values...)
+	for i := range result {
+		result[i] = strings.ToLower(strings.TrimSpace(result[i]))
+	}
+	sort.Strings(result)
+	return result
+}
+
+func copyCounts(source map[string]int) map[string]int {
+	result := make(map[string]int, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package history
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azqr/internal/findings"
+	"github.com/Azure/azqr/internal/models"
+)
+
+func TestAppendReadAndSelect(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.jsonl")
+	for index, scope := range []string{"a", "b", "a"} {
+		record := NewRecord(&findings.Summary{
+			Resources:            index + 1,
+			ImpactedResources:    index + 2,
+			RecommendationsFound: 1,
+		}, scope, "test", time.Date(2026, 1, index+1, 0, 0, 0, 0, time.UTC))
+		if err := Append(path, record); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	records, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected, scope, err := Select(records, "a", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope != "a" || len(selected) != 1 || selected[0].Resources != 3 {
+		t.Fatalf("unexpected selection: %q %+v", scope, selected)
+	}
+	if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0600 {
+		t.Fatalf("history permissions = %v, %v", info.Mode().Perm(), err)
+	}
+}
+
+func TestReadIgnoresTruncatedTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.jsonl")
+	valid := `{"schemaVersion":1,"timestamp":"2026-01-01T00:00:00Z","scopeId":"scope"}` + "\n"
+	if err := os.WriteFile(path, []byte(valid+`{"schemaVersion":1`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	records, err := Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1", len(records))
+	}
+}
+
+func TestScopeIDIsOrderIndependent(t *testing.T) {
+	first := &models.ScanParams{
+		Subscriptions: []string{"B", "a"},
+		ScannerKeys:   []string{"vm", "aks"},
+		Stages:        models.NewStageConfigsWithDefaults(),
+		Filters:       models.NewFilters(),
+	}
+	second := &models.ScanParams{
+		Subscriptions: []string{"A", "b"},
+		ScannerKeys:   []string{"aks", "vm"},
+		Stages:        models.NewStageConfigsWithDefaults(),
+		Filters:       models.NewFilters(),
+	}
+	firstID, err := ScopeID(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondID, err := ScopeID(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstID != secondID {
+		t.Fatalf("scope IDs differ: %s != %s", firstID, secondID)
+	}
+}
+
+func TestRenderTableAndJSON(t *testing.T) {
+	records := []Record{{
+		SchemaVersion:     SchemaVersion,
+		Timestamp:         time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		ScopeID:           "scope",
+		Resources:         2,
+		ImpactedResources: 1,
+		ImpactedByImpact:  map[string]int{"High": 1},
+	}}
+	table, err := Render(records, "scope", "table")
+	if err != nil || !strings.Contains(table, "FINDINGS") {
+		t.Fatalf("unexpected table: %q, %v", table, err)
+	}
+	output, err := Render(records, "scope", "json")
+	if err != nil || !strings.Contains(output, `"scopeId": "scope"`) {
+		t.Fatalf("unexpected JSON: %q, %v", output, err)
+	}
+}

--- a/internal/history/render.go
+++ b/internal/history/render.go
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package history
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/Azure/azqr/internal/models"
+)
+
+// Render formats selected history records as table or JSON.
+func Render(records []Record, scopeID, format string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "json":
+		output := struct {
+			ScopeID string   `json:"scopeId"`
+			Records []Record `json:"records"`
+		}{ScopeID: scopeID, Records: records}
+		data, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("marshal trend output: %w", err)
+		}
+		return string(data), nil
+	case "table", "":
+		return renderTable(records, scopeID), nil
+	default:
+		return "", fmt.Errorf("unsupported trend format %q: supported values are table and json", format)
+	}
+}
+
+func renderTable(records []Record, scopeID string) string {
+	var output strings.Builder
+	fmt.Fprintf(&output, "Scope: %s\n", scopeID)
+	if len(records) == 0 {
+		output.WriteString("No history records found.\n")
+		return output.String()
+	}
+
+	writer := tabwriter.NewWriter(&output, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(writer, "TIME\tRESOURCES\tFINDINGS\tHIGH\tMEDIUM\tLOW\tTREND")
+	maxFindings := 1
+	for _, record := range records {
+		if record.ImpactedResources > maxFindings {
+			maxFindings = record.ImpactedResources
+		}
+	}
+	for _, record := range records {
+		_, _ = fmt.Fprintf(
+			writer,
+			"%s\t%d\t%d\t%d\t%d\t%d\t%s\n",
+			record.Timestamp.Format("2006-01-02 15:04"),
+			record.Resources,
+			record.ImpactedResources,
+			record.ImpactedByImpact[string(models.ImpactHigh)],
+			record.ImpactedByImpact[string(models.ImpactMedium)],
+			record.ImpactedByImpact[string(models.ImpactLow)],
+			trendBar(record.ImpactedResources, maxFindings),
+		)
+	}
+	_ = writer.Flush()
+	return output.String()
+}
+
+func trendBar(value, maximum int) string {
+	if value == 0 {
+		return "-"
+	}
+	width := max(1, value*12/maximum)
+	return strings.Repeat("#", width)
+}

--- a/internal/models/scan_params.go
+++ b/internal/models/scan_params.go
@@ -23,6 +23,9 @@ type (
 		MemProfile   string
 		TraceProfile string
 		Sarif        bool
+		History      bool
+		HistoryFile  string
+		ScopeID      string
 		Version      string
 	}
 

--- a/internal/pipeline/stage_initialization.go
+++ b/internal/pipeline/stage_initialization.go
@@ -50,6 +50,7 @@ func (s *InitializationStage) Execute(ctx *ScanContext) error {
 		ctx.Params.Mask,
 		ctx.Params.Stages,
 	)
+	reportData.ScopeID = ctx.Params.ScopeID
 	ctx.ReportData = &reportData
 
 	log.Debug().Msg("Initialization stage completed")


### PR DESCRIPTION
# Description

Persists scan results to a **JSONL history file** and adds a `trend` subcommand that shows how findings have changed between scans over time.

A one-off scan tells you where you are today. History tells you whether things are getting better or worse. Tracking findings across multiple runs lets teams measure progress and catch regressions early.

### Changes
- New `--history` flag on `scan` to append results to a JSONL history file (`--history-file` to customise the path)
- Scope ID computed as a SHA-256 hash of the scanned subscriptions/resource groups so records from different scopes never mix
- New `trend` subcommand renders a table comparing the last N scans for a given scope
- New `internal/history` package with JSONL store, file locking, and trend rendering

## Issue reference

Closes #986

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing