### PR TITLE
feat: enhance SKU handling with GPU count improvements and alternative ranking logic

### DIFF
--- a/cmd/azqr/commands/alternative_vm_sku.go
+++ b/cmd/azqr/commands/alternative_vm_sku.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	alternativeVmSkuCmd.Flags().StringP("sku", "s", "", "Azure VM SKU name to find alternatives for (required)")
-	alternativeVmSkuCmd.Flags().IntP("top", "n", 3, "Number of alternative SKUs to return")
+	alternativeVmSkuCmd.Flags().IntP("top", "n", 10, "Number of alternative SKUs to return")
 	_ = alternativeVmSkuCmd.MarkFlagRequired("sku")
 	rootCmd.AddCommand(alternativeVmSkuCmd)
 }
@@ -25,16 +25,18 @@ var alternativeVmSkuCmd = &cobra.Command{
 	Long: `Find alternative Azure VM SKUs ranked by compatibility score.
 
 The compatibility score (0.0–1.0) is computed from:
-  - vCPU count match      (weight 0.30)
-  - Memory match          (weight 0.25)
-  - Same model series     (weight 0.15)
-  - Same VM family bonus  (weight 0.10)
-  - Version proximity     (weight 0.05)
-  - GPU match             (weight 0.15)
-  - Data disk match       (weight 0.05)
-  - Accelerated networking(weight 0.05)
+  - vCPU count match           (weight 0.30)
+  - Memory match               (weight 0.25)
+  - Same model series          (weight 0.15)
+  - Version proximity          (weight 0.05)
+  - GPU count match            (weight 0.15, GPU SKUs only)
+  - GPU workload class match   (weight 0.20, NV/NC/ND — GPU SKUs only)
+  - Cross-family bonus         (+0.10 for different family, scaled down 0.02/generation behind)
+  - Same-family penalty        (-0.10; same family faces the same regional capacity constraints)
+  - Data disk match            (weight 0.05)
+  - Accelerated networking     (weight 0.05)
 
-Returns the top N results (default 3) as JSON.`,
+Returns the top N results (default 10) as JSON.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		skuName, _ := cmd.Flags().GetString("sku")
 		top, _ := cmd.Flags().GetInt("top")
@@ -47,8 +49,8 @@ Returns the top N results (default 3) as JSON.`,
 		recommendations := skus.FindAlternatives(target, top)
 
 		type output struct {
-			Source           skus.SKU               `json:"source"`
-			Alternatives     []skus.Recommendation  `json:"alternatives"`
+			Source       skus.SKU              `json:"source"`
+			Alternatives []skus.Recommendation `json:"alternatives"`
 		}
 
 		enc := json.NewEncoder(os.Stdout)

--- a/hack/code/sku_gen/main.go
+++ b/hack/code/sku_gen/main.go
@@ -16,9 +16,13 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -34,7 +38,7 @@ type skuEntry struct {
 	Family                string  `yaml:"family"`
 	VCPUs                 int     `yaml:"vcpus"`
 	MemoryGB              float64 `yaml:"memoryGb"`
-	GPUCount              int     `yaml:"gpuCount"`
+	GPUCount              float64 `yaml:"gpuCount"`
 	MaxDataDisks          int     `yaml:"maxDataDisks"`
 	AcceleratedNetworking bool    `yaml:"acceleratedNetworking"`
 	DiscoveredOn          string  `yaml:"discoveredOn"`
@@ -99,12 +103,15 @@ func main() {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	log.Printf("fetched %d VM SKUs", len(names))
+
+	// Second pass: enrich GPU counts for N-series families the API does not populate.
+	enrichMissingGPUCounts(skuMap)
 
 	entries := make([]skuEntry, 0, len(names))
 	for _, name := range names {
 		entries = append(entries, skuMap[name])
 	}
-	log.Printf("fetched %d VM SKUs", len(entries))
 
 	out, err := yaml.Marshal(entries)
 	if err != nil {
@@ -133,10 +140,168 @@ func resolveSubscription() string {
 	panic("no Azure subscription found: set AZURE_SUBSCRIPTION_ID or log in with 'az login'")
 }
 
+// gpuFamilyRe matches N-series GPU VM SKU names (NV=visualization, NC=compute, ND=distributed).
+var gpuFamilyRe = regexp.MustCompile(`(?i)^Standard_N[VCD]\d`)
+
+// familyVersionRe matches the trailing version suffix in a family page name (e.g. "v5").
+var familyVersionRe = regexp.MustCompile(`(v\d+)$`)
+
+// allUpperBodyRe matches family body strings that contain only uppercase letters and digits
+// (i.e. no lowercase letters). Used to detect families with the ISR-style naming convention.
+var allUpperBodyRe = regexp.MustCompile(`^[A-Z0-9]+$`)
+
+// gpuFamilyBodyRe decomposes all-uppercase N-series family bodies into their components.
+// Groups: 1=vm-series (ND/NV/NC), 2=attribute block (ISR etc., discarded),
+// 3=GPU model (GB300/A100/H100/T4), 4=version (V6/V5), 5=trailing suffix (NDR/empty).
+// e.g. "NDISRGB300V6" → ["ND", "ISR", "GB300", "V6", ""]
+// e.g. "NDISRGB200V6NDR" → ["ND", "ISR", "GB200", "V6", "NDR"]
+var gpuFamilyBodyRe = regexp.MustCompile(`^(N[VCD])([A-Z]*?)([A-Z]{1,2}\d+)(V\d+)([A-Z]*)$`)
+
+// tableRowRe matches a Markdown table row whose first cell is a Standard_N VM SKU name
+// and whose second cell is a GPU accelerator quantity (fraction or integer).
+// e.g. "| Standard_NV4ads_V710_v5 | 1/6 | 4 |"
+var tableRowRe = regexp.MustCompile(`\|\s*(Standard_N\w+)\s*\|\s*([0-9/]+)\s*\|`)
+
+// fracRe matches fraction strings such as "1/6".
+var fracRe = regexp.MustCompile(`^(\d+)/(\d+)$`)
+
+// familyToDocPage derives the Azure docs page name from a VM family name.
+//
+// Two naming conventions exist:
+//   - CamelCase: "StandardNVadsV710v5Family" → "nvadsv710-v5-series"
+//   - All-uppercase body: "standardNDISRGB300V6Family" → "nd-gb300-v6-series"
+//     (Azure omits the ISR-style attribute block from the docs URL)
+func familyToDocPage(family string) string {
+	// Strip "Standard"/"standard" prefix and "Family"/"family" suffix.
+	s := family
+	for _, p := range []string{"Standard", "standard"} {
+		if strings.HasPrefix(s, p) {
+			s = s[len(p):]
+			break
+		}
+	}
+	for _, p := range []string{"Family", "family"} {
+		if strings.HasSuffix(s, p) {
+			s = s[:len(s)-len(p)]
+			break
+		}
+	}
+
+	// All-uppercase body: extract vm-series, GPU model, version, and optional trailing suffix.
+	// e.g. "NDISRGB300V6" → nd-gb300-v6, "NDISRGB200V6NDR" → nd-gb200-v6-ndr
+	if allUpperBodyRe.MatchString(s) {
+		if m := gpuFamilyBodyRe.FindStringSubmatch(s); m != nil {
+			// Azure drops both the middle attribute block (m[2]: ISR) and the trailing
+			// hardware suffix (m[5]: NDR) from docs URLs — only vm-series, GPU model,
+			// and version are retained.
+			// e.g. NDISRGB300V6 → nd-gb300-v6, NDISRGB200V6NDR → nd-gb200-v6
+			parts := []string{strings.ToLower(m[1]), strings.ToLower(m[3]), strings.ToLower(m[4])}
+			return strings.Join(parts, "-") + "-series"
+		}
+	}
+
+	// CamelCase fallback: insert a dash before the trailing version suffix.
+	// e.g. "NVadsV710v5" → "nvadsv710-v5-series"
+	s = familyVersionRe.ReplaceAllString(s, "-$1")
+	return strings.ToLower(s) + "-series"
+}
+
+// parseFraction converts "1/6" → ~0.1667 and "1" → 1.0.
+func parseFraction(s string) float64 {
+	s = strings.TrimSpace(s)
+	if m := fracRe.FindStringSubmatch(s); m != nil {
+		num, _ := strconv.ParseFloat(m[1], 64)
+		den, _ := strconv.ParseFloat(m[2], 64)
+		if den > 0 {
+			return num / den
+		}
+	}
+	v, _ := strconv.ParseFloat(s, 64)
+	return v
+}
+
+// fetchAcceleratorsFromDocs fetches the Accelerators table from the public Azure docs
+// GitHub repository for the given page name and returns a map of SKU name → GPU count.
+func fetchAcceleratorsFromDocs(page string) (map[string]float64, error) {
+	url := fmt.Sprintf(
+		"https://raw.githubusercontent.com/MicrosoftDocs/azure-compute-docs/main/articles/virtual-machines/sizes/gpu-accelerated/%s.md",
+		page,
+	)
+	resp, err := http.Get(url) //nolint:noctx
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	// Markdown escapes underscores in table cells (Standard\_NV4ads\_V710\_v5); normalise.
+	content := strings.ReplaceAll(string(body), `\_`, "_")
+
+	// The page has multiple tables (vCPUs, memory, network, accelerators).
+	// Narrow to the Accelerators tab section to avoid picking up vCPU counts.
+	if idx := strings.Index(content, "tab/sizeaccelerators"); idx != -1 {
+		content = content[idx:]
+	} else if idx := strings.Index(content, "Accelerators (Qty.)"); idx != -1 {
+		content = content[idx:]
+	}
+
+	result := make(map[string]float64)
+	for _, m := range tableRowRe.FindAllStringSubmatch(content, -1) {
+		count := parseFraction(m[2])
+		if count > 0 {
+			result[strings.TrimSpace(m[1])] = count
+		}
+	}
+	return result, nil
+}
+
+// enrichMissingGPUCounts performs a second pass over the SKU map. For every N-series
+// GPU family where all SKUs still report gpuCount=0 (meaning the Azure ResourceSKUs API
+// omits GPU metadata entirely), it fetches the Accelerators table from the Azure docs
+// and applies the correct fractional GPU counts.
+func enrichMissingGPUCounts(skuMap map[string]skuEntry) {
+	// Count total and zero-GPU SKUs per N-series family.
+	total := make(map[string]int)
+	zeros := make(map[string]int)
+	for _, e := range skuMap {
+		if gpuFamilyRe.MatchString(e.Name) {
+			total[e.Family]++
+			if e.GPUCount == 0 {
+				zeros[e.Family]++
+			}
+		}
+	}
+	for family, t := range total {
+		if zeros[family] < t {
+			continue // API already returned GPU data for this family
+		}
+		page := familyToDocPage(family)
+		log.Printf("enriching GPU counts for %s from docs (%s)", family, page)
+		counts, err := fetchAcceleratorsFromDocs(page)
+		if err != nil {
+			log.Printf("warning: could not enrich GPU counts for %s: %v", family, err)
+			continue
+		}
+		for name, count := range counts {
+			if e, ok := skuMap[name]; ok && e.GPUCount == 0 {
+				e.GPUCount = count
+				skuMap[name] = e
+				log.Printf("  %s gpuCount=%.4f", name, count)
+			}
+		}
+	}
+}
+
 // extractCapabilities reads relevant capabilities from a SKU into a skuEntry.
 func extractCapabilities(sku *armcompute.ResourceSKU) skuEntry {
 	var e skuEntry
 	var vCPUs, vCPUsAvailable int
+	var gpus float64
 	for _, cap := range sku.Capabilities {
 		if cap.Name == nil || cap.Value == nil {
 			continue
@@ -149,7 +314,7 @@ func extractCapabilities(sku *armcompute.ResourceSKU) skuEntry {
 		case "MemoryGB":
 			e.MemoryGB, _ = strconv.ParseFloat(*cap.Value, 64)
 		case "GPUs":
-			e.GPUCount, _ = strconv.Atoi(*cap.Value)
+			gpus, _ = strconv.ParseFloat(*cap.Value, 64)
 		case "MaxDataDiskCount":
 			e.MaxDataDisks, _ = strconv.Atoi(*cap.Value)
 		case "AcceleratedNetworkingEnabled":
@@ -161,6 +326,7 @@ func extractCapabilities(sku *armcompute.ResourceSKU) skuEntry {
 	} else {
 		e.VCPUs = vCPUs
 	}
+	e.GPUCount = gpus
 	return e
 }
 

--- a/internal/skus/advisor.go
+++ b/internal/skus/advisor.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"slices"
 	"strconv"
+	"strings"
 )
 
 // Recommendation represents an alternative SKU suggestion with a compatibility score.
@@ -21,6 +22,10 @@ var versionRe = regexp.MustCompile(`(?i)_v(\d+)`)
 
 // baseNameRe strips the _vN… suffix to produce the base model name (e.g. "Standard_D16s").
 var baseNameRe = regexp.MustCompile(`(?i)_v\d+.*$`)
+
+// gpuCategoryRe matches the GPU workload class prefix in N-series SKU names.
+// Groups: 1=category letter (V=visualization, C=compute, D=distributed).
+var gpuCategoryRe = regexp.MustCompile(`(?i)^Standard_N([VCD])\d`)
 
 // extractVersion returns the generation version found in the SKU name, or 0 if absent.
 func extractVersion(name string) int {
@@ -36,6 +41,17 @@ func extractVersion(name string) int {
 // (e.g. "Standard_D16s_v5" → "Standard_D16s", "Standard_D11_v2_Promo" → "Standard_D11").
 func extractBaseName(name string) string {
 	return baseNameRe.ReplaceAllString(name, "")
+}
+
+// extractGPUCategory returns the GPU workload class for N-series SKU names:
+// "V" for visualization (NV), "C" for compute (NC), "D" for distributed (ND).
+// Returns "" for non-GPU SKUs.
+func extractGPUCategory(name string) string {
+	m := gpuCategoryRe.FindStringSubmatch(name)
+	if m == nil {
+		return ""
+	}
+	return strings.ToUpper(m[1])
 }
 
 // FindAlternatives returns the top n alternative SKUs for the given target SKU,
@@ -79,14 +95,15 @@ func FindAlternatives(target SKU, n int) []Recommendation {
 //
 // Weight budget (total may exceed 1.0 and is capped):
 //
-//	vCPUs           0.30
-//	Memory          0.25
-//	Same base model 0.15  (same SKU name ignoring _vN suffix, e.g. Standard_D16s)
-//	Family          0.10  (same Azure VM family string)
-//	Version         0.05  (same/newer: 0.05; each generation behind costs 0.02, min 0.0)
-//	GPU             0.15  (or 0.10 flat for non-GPU workloads)
-//	Data disks      0.05
-//	Accel. network  0.05
+//	vCPUs               0.30
+//	Memory              0.25
+//	Same base model     0.15  (same SKU name ignoring _vN suffix, e.g. Standard_D16s)
+//	Family              same=-0.10 / cross=+0.10 scaled by generation gap
+//	Version             0.05  (same/newer: 0.05; each generation behind costs 0.02, min 0.0)
+//	GPU count           0.15  (or 0.10 flat for non-GPU workloads)
+//	GPU workload class  0.20  (NV/NC/ND same class bonus, GPU SKUs only)
+//	Data disks          0.05
+//	Accel. network      0.05
 func computeScore(target, candidate SKU) float64 {
 	var total float64
 
@@ -115,23 +132,44 @@ func computeScore(target, candidate SKU) float64 {
 		total += 0.15
 	}
 
-	// Same-family bonus (weight 0.10).
+	// Cross-family scoring: different families draw from independent capacity pools,
+	// making them more useful alternatives when the target family is constrained.
+	// Same-family candidates are penalized (-0.10) since they face the same capacity limits.
+	// Cross-family bonus: 0.10 base, reduced by 0.02 per generation behind the target, floor 0.0.
 	if target.Family != "" && target.Family == candidate.Family {
-		total += 0.10
+		total -= 0.10
+	} else {
+		diff := extractVersion(target.Name) - extractVersion(candidate.Name)
+		if diff < 0 {
+			diff = 0
+		}
+		bonus := 0.10 - float64(diff)*0.02
+		if bonus > 0 {
+			total += bonus
+		}
 	}
 
 	// Version proximity (weight 0.05).
 	total += scoreVersion(extractVersion(target.Name), extractVersion(candidate.Name))
 
-	// GPU match (weight 0.15)
+	// GPU count match (weight 0.15)
 	if target.GPUCount > 0 {
 		if candidate.GPUCount >= target.GPUCount {
 			total += 0.15
 		} else if candidate.GPUCount > 0 {
-			total += float64(candidate.GPUCount) / float64(target.GPUCount) * 0.15
+			total += (candidate.GPUCount / target.GPUCount) * 0.15
+		}
+
+		// GPU workload class bonus (weight 0.20): NV=visualization, NC=compute, ND=distributed.
+		// Weighted higher than memory because GPU VM sizing is driven by partition count/workload
+		// type, not raw RAM — a same-class candidate is always preferable regardless of memory gap.
+		targetCat := extractGPUCategory(target.Name)
+		candidateCat := extractGPUCategory(candidate.Name)
+		if targetCat != "" && targetCat == candidateCat {
+			total += 0.20
 		}
 	} else {
-		total += 0.10 // non-GPU workload
+		total += 0.10 // non-GPU workload flat bonus
 	}
 
 	// Data disk match (weight 0.05)

--- a/internal/skus/advisor_test.go
+++ b/internal/skus/advisor_test.go
@@ -119,8 +119,84 @@ func TestExtractBaseName(t *testing.T) {
 	}
 }
 
-// TestFindAlternatives_SameModelVersionsRankFirst ensures that same-series SKUs
-// (e.g. Standard_D16s_v4, Standard_D16s_v6) appear before unrelated SKUs.
+// TestExtractGPUCategory verifies workload class extraction from N-series SKU names.
+func TestExtractGPUCategory(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"Standard_NV36ads_A10_v5", "V"},
+		{"Standard_NV4ads_V710_v5", "V"},
+		{"Standard_NC64as_T4_v3", "C"},
+		{"Standard_NC48ads_A100_v4", "C"},
+		{"Standard_ND96asr_v4", "D"},
+		{"Standard_D4s_v5", ""},  // not N-series
+		{"Standard_B4ms", ""},
+	}
+	for _, tt := range tests {
+		got := extractGPUCategory(tt.name)
+		if got != tt.want {
+			t.Errorf("extractGPUCategory(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+// TestFindAlternatives_V710AppearsForA10 verifies that NVads V710 v5 SKUs surface
+// when searching for alternatives to an NVads A10 v5 SKU of comparable size.
+func TestFindAlternatives_V710AppearsForA10(t *testing.T) {
+	// Use NV12ads_A10_v5: the V710 equivalent (NV12ads_V710_v5) has a comparable
+	// memory footprint (64 GB vs 110 GB), so it should rank in the top alternatives.
+	target, ok := Lookup("Standard_NV12ads_A10_v5")
+	if !ok {
+		t.Skip("Standard_NV12ads_A10_v5 not found in known_skus.yaml")
+	}
+
+	results := FindAlternatives(target, 10)
+
+	found := false
+	for _, r := range results {
+		if r.SKU.Family == "StandardNVadsV710v5Family" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one NVads V710 v5 SKU in top-10 alternatives for Standard_NV12ads_A10_v5")
+	}
+}
+
+// TestFindAlternatives_NVAlternativesRankAboveNC verifies that NV (visualization)
+// alternatives rank above NC (compute) alternatives for an NV source SKU.
+func TestFindAlternatives_NVAlternativesRankAboveNC(t *testing.T) {
+	target, ok := Lookup("Standard_NV36ads_A10_v5")
+	if !ok {
+		t.Skip("Standard_NV36ads_A10_v5 not found in known_skus.yaml")
+	}
+
+	results := FindAlternatives(target, 0) // all results
+
+	nvPos, ncPos := -1, -1
+	for i, r := range results {
+		cat := extractGPUCategory(r.SKU.Name)
+		if cat == "V" && nvPos == -1 {
+			nvPos = i
+		}
+		if cat == "C" && ncPos == -1 {
+			ncPos = i
+		}
+		if nvPos != -1 && ncPos != -1 {
+			break
+		}
+	}
+
+	if nvPos == -1 || ncPos == -1 {
+		t.Skip("need both NV and NC alternatives to compare ranking")
+	}
+	if nvPos > ncPos {
+		t.Errorf("first NV alternative (pos %d) should rank above first NC alternative (pos %d)", nvPos, ncPos)
+	}
+}
+
 func TestFindAlternatives_SameModelVersionsRankFirst(t *testing.T) {
 	target, ok := Lookup("Standard_D16s_v5")
 	if !ok {

--- a/internal/skus/known_skus.yaml
+++ b/internal/skus/known_skus.yaml
@@ -1551,6 +1551,38 @@
   maxDataDisks: 8
   acceleratedNetworking: false
   discoveredOn: "2026-07-03"
+- name: Standard_D248ds_v7
+  family: StandardDdsv7Family
+  vcpus: 248
+  memoryGb: 992
+  gpuCount: 0
+  maxDataDisks: 64
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
+- name: Standard_D248lds_v7
+  family: StandardDldsv7Family
+  vcpus: 248
+  memoryGb: 496
+  gpuCount: 0
+  maxDataDisks: 64
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
+- name: Standard_D248ls_v7
+  family: StandardDlsv7Family
+  vcpus: 248
+  memoryGb: 496
+  gpuCount: 0
+  maxDataDisks: 64
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
+- name: Standard_D248s_v7
+  family: StandardDsv7Family
+  vcpus: 248
+  memoryGb: 992
+  gpuCount: 0
+  maxDataDisks: 64
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
 - name: Standard_D2_v2
   family: standardDv2Family
   vcpus: 2
@@ -2279,6 +2311,22 @@
   maxDataDisks: 64
   acceleratedNetworking: true
   discoveredOn: "2026-07-03"
+- name: Standard_D372ds_v7
+  family: StandardDdsv7Family
+  vcpus: 372
+  memoryGb: 1488
+  gpuCount: 0
+  maxDataDisks: 64
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
+- name: Standard_D372s_v7
+  family: StandardDsv7Family
+  vcpus: 372
+  memoryGb: 1488
+  gpuCount: 0
+  maxDataDisks: 64
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
 - name: Standard_D3_v2
   family: standardDv2Family
   vcpus: 4
@@ -4135,6 +4183,14 @@
   maxDataDisks: 4
   acceleratedNetworking: true
   discoveredOn: "2026-07-03"
+- name: Standard_DC1s_v2
+  family: standardDCSv2Family
+  vcpus: 1
+  memoryGb: 4
+  gpuCount: 0
+  maxDataDisks: 1
+  acceleratedNetworking: false
+  discoveredOn: "2026-08-27"
 - name: Standard_DC1s_v3
   family: standardDCSv3Family
   vcpus: 1
@@ -4231,6 +4287,14 @@
   maxDataDisks: 8
   acceleratedNetworking: false
   discoveredOn: "2026-07-03"
+- name: Standard_DC2s_v2
+  family: standardDCSv2Family
+  vcpus: 2
+  memoryGb: 8
+  gpuCount: 0
+  maxDataDisks: 2
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
 - name: Standard_DC2s_v3
   family: standardDCSv3Family
   vcpus: 2
@@ -4519,6 +4583,14 @@
   maxDataDisks: 12
   acceleratedNetworking: false
   discoveredOn: "2026-07-03"
+- name: Standard_DC4s_v2
+  family: standardDCSv2Family
+  vcpus: 4
+  memoryGb: 16
+  gpuCount: 0
+  maxDataDisks: 4
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
 - name: Standard_DC4s_v3
   family: standardDCSv3Family
   vcpus: 4
@@ -4607,6 +4679,14 @@
   maxDataDisks: 64
   acceleratedNetworking: false
   discoveredOn: "2026-07-03"
+- name: Standard_DC8_v2
+  family: standardDCSv2Family
+  vcpus: 8
+  memoryGb: 32
+  gpuCount: 0
+  maxDataDisks: 8
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
 - name: Standard_DC8ads_cc_v5
   family: standardDCADCCV5Family
   vcpus: 8
@@ -5895,6 +5975,22 @@
   maxDataDisks: 48
   acceleratedNetworking: true
   discoveredOn: "2026-07-03"
+- name: Standard_E248ds_v7
+  family: StandardEdsv7Family
+  vcpus: 248
+  memoryGb: 1888
+  gpuCount: 0
+  maxDataDisks: 64
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
+- name: Standard_E248s_v7
+  family: StandardEsv7Family
+  vcpus: 248
+  memoryGb: 1888
+  gpuCount: 0
+  maxDataDisks: 64
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
 - name: Standard_E2_v3
   family: standardEv3Family
   vcpus: 2
@@ -6567,6 +6663,22 @@
   maxDataDisks: 64
   acceleratedNetworking: true
   discoveredOn: "2026-07-03"
+- name: Standard_E372ids_v7
+  family: StandardEdsv7Family
+  vcpus: 372
+  memoryGb: 2832
+  gpuCount: 0
+  maxDataDisks: 64
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
+- name: Standard_E372is_v7
+  family: StandardEsv7Family
+  vcpus: 372
+  memoryGb: 2832
+  gpuCount: 0
+  maxDataDisks: 64
+  acceleratedNetworking: true
+  discoveredOn: "2026-08-27"
 - name: Standard_E4-2ads_v5
   family: standardEADSv5Family
   vcpus: 2
@@ -12163,7 +12275,7 @@
   family: standardNDISRGB300V6Family
   vcpus: 128
   memoryGb: 864
-  gpuCount: 0
+  gpuCount: 4
   maxDataDisks: 16
   acceleratedNetworking: true
   discoveredOn: "2026-07-03"
@@ -12171,7 +12283,7 @@
   family: standardNDISRGB200V6NDRFamily
   vcpus: 128
   memoryGb: 864
-  gpuCount: 0
+  gpuCount: 4
   maxDataDisks: 16
   acceleratedNetworking: true
   discoveredOn: "2026-07-03"
@@ -12299,7 +12411,7 @@
   family: StandardNVadsV710v5Family
   vcpus: 12
   memoryGb: 64
-  gpuCount: 0
+  gpuCount: 0.5
   maxDataDisks: 6
   acceleratedNetworking: true
   discoveredOn: "2026-07-03"
@@ -12339,7 +12451,7 @@
   family: StandardNVadsV710v5Family
   vcpus: 24
   memoryGb: 128
-  gpuCount: 0
+  gpuCount: 1
   maxDataDisks: 12
   acceleratedNetworking: true
   discoveredOn: "2026-07-03"
@@ -12395,7 +12507,7 @@
   family: StandardNVadsV710v5Family
   vcpus: 4
   memoryGb: 16
-  gpuCount: 0
+  gpuCount: 0.16666666666666666
   maxDataDisks: 2
   acceleratedNetworking: true
   discoveredOn: "2026-07-03"
@@ -12435,7 +12547,7 @@
   family: StandardNVadsV710v5Family
   vcpus: 8
   memoryGb: 32
-  gpuCount: 0
+  gpuCount: 0.3333333333333333
   maxDataDisks: 4
   acceleratedNetworking: true
   discoveredOn: "2026-07-03"

--- a/internal/skus/skus.go
+++ b/internal/skus/skus.go
@@ -21,7 +21,7 @@ type SKU struct {
 	Family                string  `yaml:"family"                json:"family"`
 	VCPUs                 int     `yaml:"vcpus"                 json:"vcpus"`
 	MemoryGB              float64 `yaml:"memoryGb"              json:"memoryGb"`
-	GPUCount              int     `yaml:"gpuCount"              json:"gpuCount"`
+	GPUCount              float64 `yaml:"gpuCount"              json:"gpuCount"`
 	MaxDataDisks          int     `yaml:"maxDataDisks"          json:"maxDataDisks"`
 	AcceleratedNetworking bool    `yaml:"acceleratedNetworking" json:"acceleratedNetworking"`
 }


### PR DESCRIPTION
# Description

This pull request introduces significant improvements to the Azure VM SKU alternative advisor, with a focus on more accurate GPU SKU handling, a refined compatibility scoring algorithm, and expanded test coverage. It also updates the known SKU database with new VM types.

**Key changes:**

### Compatibility Scoring Algorithm Improvements

* The alternative SKU compatibility scoring logic has been overhauled to better reflect real-world Azure VM constraints and GPU workload requirements. Notable changes include:
  - Cross-family SKUs are now favored over same-family SKUs (which are penalized), as they are less likely to face the same regional capacity constraints. The cross-family bonus is scaled down for older generations. [[1]](diffhunk://#diff-654207739f68c9a6dbd754029e4d1a6be1e11ed928889cf4eaf285541bd23334L118-R170) [[2]](diffhunk://#diff-cf04b5c9ea9c3644410fc530c4ede1dc6f008c78ef8c6292c05c98843d74d256L31-R39)
  - GPU scoring is now split into GPU count (fractional values supported) and GPU workload class (NV/NC/ND), with a higher weight for matching the same GPU workload class. [[1]](diffhunk://#diff-654207739f68c9a6dbd754029e4d1a6be1e11ed928889cf4eaf285541bd23334L85-R104) [[2]](diffhunk://#diff-654207739f68c9a6dbd754029e4d1a6be1e11ed928889cf4eaf285541bd23334L118-R170) [[3]](diffhunk://#diff-cf04b5c9ea9c3644410fc530c4ede1dc6f008c78ef8c6292c05c98843d74d256L31-R39)
  - The scoring weights and descriptions have been updated throughout the codebase and CLI help text to reflect these changes. [[1]](diffhunk://#diff-cf04b5c9ea9c3644410fc530c4ede1dc6f008c78ef8c6292c05c98843d74d256L31-R39) [[2]](diffhunk://#diff-654207739f68c9a6dbd754029e4d1a6be1e11ed928889cf4eaf285541bd23334L85-R104)

### GPU SKU Handling and Data Enrichment

* The SKU generator now fetches missing GPU counts for N-series SKUs directly from the Azure documentation when the Azure API omits this information, supporting fractional GPU counts (e.g., 1/6 GPU per VM). This ensures more accurate recommendations for GPU SKUs. [[1]](diffhunk://#diff-efd887f4d74ee4f238d1061295a0328b59403ab1d418cab741a04efef89bf0b6L37-R41) [[2]](diffhunk://#diff-efd887f4d74ee4f238d1061295a0328b59403ab1d418cab741a04efef89bf0b6R143-R304) [[3]](diffhunk://#diff-efd887f4d74ee4f238d1061295a0328b59403ab1d418cab741a04efef89bf0b6R106-L107) [[4]](diffhunk://#diff-efd887f4d74ee4f238d1061295a0328b59403ab1d418cab741a04efef89bf0b6L152-R317) [[5]](diffhunk://#diff-efd887f4d74ee4f238d1061295a0328b59403ab1d418cab741a04efef89bf0b6R329)
* The internal SKU data structure and extraction logic have been updated to support fractional GPU counts. [[1]](diffhunk://#diff-efd887f4d74ee4f238d1061295a0328b59403ab1d418cab741a04efef89bf0b6L37-R41) [[2]](diffhunk://#diff-efd887f4d74ee4f238d1061295a0328b59403ab1d418cab741a04efef89bf0b6L152-R317) [[3]](diffhunk://#diff-efd887f4d74ee4f238d1061295a0328b59403ab1d418cab741a04efef89bf0b6R329)

### CLI and Usability Enhancements

* The default number of alternative SKUs returned by the CLI has been increased from 3 to 10, making it easier for users to discover viable options. [[1]](diffhunk://#diff-cf04b5c9ea9c3644410fc530c4ede1dc6f008c78ef8c6292c05c98843d74d256L17-R17) [[2]](diffhunk://#diff-cf04b5c9ea9c3644410fc530c4ede1dc6f008c78ef8c6292c05c98843d74d256L31-R39)

### Test Coverage and Correctness

* New tests have been added to verify correct extraction of GPU workload class, correct ranking of NV (visualization) alternatives above NC (compute) for NV SKUs, and that V710-based SKUs appear as alternatives for A10-based SKUs.

These changes make the alternative SKU advisor more accurate, especially for GPU workloads, and provide users with a broader and more relevant set of alternative VM recommendations.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1001 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
