### PR TITLE
fix: reorder CodeQL initialization step in workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,17 +48,17 @@ jobs:
         fetch-depth: 0
         submodules: "recursive"
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
-      with:
-        languages: ${{ matrix.language }}
-
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version-file: "go.mod"
         cache: true
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+      with:
+        languages: ${{ matrix.language }}
 
     - name: Build
       run: make build


### PR DESCRIPTION
# Description

This pull request makes a minor adjustment to the `codeql.yml` GitHub Actions workflow by moving the "Initialize CodeQL" step to occur after setting up Go. This change ensures that Go is properly set up before initializing CodeQL, which may help with accurate scanning of Go code.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
