### PR TITLE
feat: add recommendations for MySQL and PostgreSQL Flexible Servers regarding Extended Security Updates (ESU) 

### DIFF
--- a/data/recommendations.json
+++ b/data/recommendations.json
@@ -2440,6 +2440,14 @@
 		"resourceType": "Microsoft.DBforMySQL/flexibleServers"
 	},
 	{
+		"category": "Governance",
+		"impact": "High",
+		"learnMoreUrl": "https://learn.microsoft.com/en-us/azure/mysql/concepts-version-policy",
+		"recommendation": "Azure Database for MySQL - Flexible Server is running a version subject to Extended Security Updates (ESU) billing",
+		"recommendationId": "mysqlf-005",
+		"resourceType": "Microsoft.DBforMySQL/flexibleServers"
+	},
+	{
 		"category": "SLA",
 		"impact": "High",
 		"learnMoreUrl": "https://www.microsoft.com/licensing/docs/view/Service-Level-Agreements-SLA-for-Online-Services",
@@ -2557,6 +2565,14 @@
 		"learnMoreUrl": "https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-networking-private-link",
 		"recommendation": "PostgreSQL should have private access enabled",
 		"recommendationId": "psqlf-004",
+		"resourceType": "Microsoft.DBforPostgreSQL/flexibleServers"
+	},
+	{
+		"category": "Governance",
+		"impact": "High",
+		"learnMoreUrl": "https://learn.microsoft.com/en-us/azure/postgresql/configure-maintain/concepts-version-policy",
+		"recommendation": "PostgreSQL Flexible Server is running a version subject to Extended Security Updates (ESU) billing",
+		"recommendationId": "psqlf-005",
 		"resourceType": "Microsoft.DBforPostgreSQL/flexibleServers"
 	},
 	{

--- a/internal/graph/azqr/azure-resources/DBforMySQL/servers/kql/mysqlf-005.kql
+++ b/internal/graph/azqr/azure-resources/DBforMySQL/servers/kql/mysqlf-005.kql
@@ -1,0 +1,12 @@
+// Check if MySQL Flexible Server is running a version subject to Extended Security Updates (ESU) billing
+resources
+| where type =~ 'Microsoft.DBforMySQL/flexibleServers'
+| extend mysqlVersion = tostring(properties.version)
+| where mysqlVersion startswith '5.7' or mysqlVersion startswith '8.0'
+| extend esuStartDate = case(
+    mysqlVersion startswith '8.0', '2027-01-01',
+    '2026-08-01')
+| extend recommendationId = 'mysqlf-005'
+| extend param1 = strcat('MySQL version: ', mysqlVersion)
+| extend param2 = strcat('ESU start date: ', esuStartDate)
+| project recommendationId, name, id, tags, param1, param2

--- a/internal/graph/azqr/azure-resources/DBforMySQL/servers/recommendations.yaml
+++ b/internal/graph/azqr/azure-resources/DBforMySQL/servers/recommendations.yaml
@@ -78,3 +78,19 @@
   - name: Learn more
     url: 'https://learn.microsoft.com/azure/mysql/flexible-server/concepts-networking-vnet'
 
+- description: Azure Database for MySQL - Flexible Server is running a version subject to Extended Security Updates (ESU) billing
+  aprlGuid: mysqlf-005
+  recommendationTypeId: null
+  recommendationControl: Governance
+  recommendationImpact: High
+  recommendationResourceType: Microsoft.DBforMySQL/flexibleServers
+  recommendationMetadataState: Active
+  longDescription: 'Azure Database for MySQL - Flexible Servers running major version 5.7 or 8.0 have reached, or are approaching, the end of Azure Standard Support and are billed for Extended Security Updates (ESU). Perform a Major Version Upgrade to a supported version to avoid ESU charges.'
+  potentialBenefits: Avoid Extended Security Updates (ESU) billing by upgrading to a supported major version
+  pgVerified: true
+  automationAvailable: true
+  tags: []
+  learnMoreLink:
+  - name: Learn more
+    url: 'https://learn.microsoft.com/en-us/azure/mysql/concepts-version-policy'
+

--- a/internal/graph/azqr/azure-resources/DBforPostgreSQL/flexibleServers/kql/psqlf-005.kql
+++ b/internal/graph/azqr/azure-resources/DBforPostgreSQL/flexibleServers/kql/psqlf-005.kql
@@ -1,0 +1,12 @@
+// Check if PostgreSQL Flexible Server is running a version subject to Extended Security Updates (ESU) billing
+resources
+| where type =~ 'Microsoft.DBforPostgreSQL/flexibleServers'
+| extend pgVersion = tostring(properties.version)
+| where pgVersion in ('11', '12', '13', '14')
+| extend esuStartDate = case(
+    pgVersion == '14', '2026-12-12',
+    '2026-08-01')
+| extend recommendationId = 'psqlf-005'
+| extend param1 = strcat('PostgreSQL version: ', pgVersion)
+| extend param2 = strcat('ESU start date: ', esuStartDate)
+| project recommendationId, name, id, tags, param1, param2

--- a/internal/graph/azqr/azure-resources/DBforPostgreSQL/flexibleServers/recommendations.yaml
+++ b/internal/graph/azqr/azure-resources/DBforPostgreSQL/flexibleServers/recommendations.yaml
@@ -29,3 +29,19 @@
   learnMoreLink:
   - name: Private access (VNet Integration)
     url: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-networking#private-access-vnet-integration
+
+- description: PostgreSQL Flexible Server is running a version subject to Extended Security Updates (ESU) billing
+  aprlGuid: psqlf-005
+  recommendationTypeId: null
+  recommendationControl: Governance
+  recommendationImpact: High
+  recommendationResourceType: Microsoft.DBforPostgreSQL/flexibleServers
+  recommendationMetadataState: Active
+  longDescription: 'PostgreSQL Flexible Servers running major versions 11, 12, 13 or 14 have reached, or are approaching, the end of Azure Standard Support and are billed for Extended Security Updates (ESU). Perform a Major Version Upgrade to PostgreSQL 15 or later to avoid ESU charges.'
+  potentialBenefits: Avoid Extended Security Updates (ESU) billing by upgrading to a supported major version
+  pgVerified: true
+  automationAvailable: true
+  tags: []
+  learnMoreLink:
+  - name: Azure Database for PostgreSQL Flexible Server versioning policy
+    url: https://learn.microsoft.com/en-us/azure/postgresql/configure-maintain/concepts-version-policy


### PR DESCRIPTION
# Description

This pull request adds new recommendations and detection logic for Azure Database for MySQL and PostgreSQL Flexible Servers that are running versions subject to Extended Security Updates (ESU) billing. These recommendations help users identify servers that may incur additional charges and encourage upgrades to supported versions.

**New ESU Billing Recommendations:**

*MySQL Flexible Server:*
- Added a new recommendation (`mysqlf-005`) to flag MySQL Flexible Servers running versions 5.7 or 8.0, which are subject to ESU billing. Includes detection logic (`mysqlf-005.kql`), metadata in `recommendations.yaml`, and entry in `recommendations.json`. [[1]](diffhunk://#diff-9e6fa880133c7ccf0aff47dfa745589a47d4003ae5f5032e9339bf505c8c1fdfR1-R12) [[2]](diffhunk://#diff-2756c4bb274d6748bc9e04cd0cbd6d393cb00c2c2be082fcc5bec43235a30a2eR81-R96) [[3]](diffhunk://#diff-c3a366060d717fe2190cdf8382d95dc508e004b5ba9de5166ad39c6913ceb336R2442-R2449)

*PostgreSQL Flexible Server:*
- Added a new recommendation (`psqlf-005`) to flag PostgreSQL Flexible Servers running versions 11, 12, 13, or 14, which are subject to ESU billing. Includes detection logic (`psqlf-005.kql`), metadata in `recommendations.yaml`, and entry in `recommendations.json`. [[1]](diffhunk://#diff-90a74f3c439b475c92d25dc7c59c95daf0b8e0b3777fc464f1e8c1e878cc2f0aR1-R12) [[2]](diffhunk://#diff-f44b00dedaa24888e2d7b8aab8749f5b6f10ef931333110be7e6e9a462283e9aR32-R47) [[3]](diffhunk://#diff-c3a366060d717fe2190cdf8382d95dc508e004b5ba9de5166ad39c6913ceb336R2570-R2577)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1019

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
